### PR TITLE
Build Mixxx with mesa3d+lima driver

### DIFF
--- a/buildroot-config/.config
+++ b/buildroot-config/.config
@@ -580,6 +580,7 @@ BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 # kodi needs python3 w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 4.9
 #
 BR2_PACKAGE_KODI_PLATFORM_SUPPORTS=y
+BR2_PACKAGE_KODI_PLATFORM_SUPPORTS_GBM=y
 BR2_PACKAGE_KODI_PLATFORM_SUPPORTS_X11=y
 BR2_PACKAGE_LAME=y
 # BR2_PACKAGE_MADPLAY is not set
@@ -871,13 +872,27 @@ BR2_PACKAGE_DEJAVU_SERIF_CONDENSED=y
 # BR2_PACKAGE_GNUCHESS is not set
 # BR2_PACKAGE_LBREAKOUT2 is not set
 # BR2_PACKAGE_LTRIS is not set
-# BR2_PACKAGE_LUGARU is not set
+
+#
+# lugaru needs X11 and a toolchain w/ C++, OpenGL backend, gcc >= 4.9, NPTL, dynamic library
+#
+
+#
+# minetest needs X11 and an OpenGL provider
+#
 # BR2_PACKAGE_OPENTYRIAN is not set
 # BR2_PACKAGE_PRBOOM is not set
 # BR2_PACKAGE_RUBIX is not set
 # BR2_PACKAGE_SL is not set
+
+#
+# solarus needs OpenGL and a toolchain w/ C++, gcc >= 4.9, NPTL, dynamic library, and luajit or lua 5.1
+#
 # BR2_PACKAGE_STELLA is not set
-# BR2_PACKAGE_SUPERTUX is not set
+
+#
+# supertux needs OpenGL and a toolchain w/ C++, gcc >= 6, NPTL, dynamic library, wchar
+#
 # BR2_PACKAGE_XORCURSES is not set
 
 #
@@ -898,9 +913,8 @@ BR2_PACKAGE_DEJAVU_SERIF_CONDENSED=y
 # BR2_PACKAGE_FSWEBCAM is not set
 # BR2_PACKAGE_GHOSTSCRIPT is not set
 BR2_PACKAGE_GLMARK2_FLAVOR_ANY=y
-BR2_PACKAGE_GLMARK2_FLAVOR_DRM_GL=y
+BR2_PACKAGE_GLMARK2_FLAVOR_DRM_GLESV2=y
 BR2_PACKAGE_GLMARK2_FLAVOR_X11_GLESV2=y
-BR2_PACKAGE_GLMARK2_FLAVOR_X11_GL=y
 # BR2_PACKAGE_GLMARK2 is not set
 # BR2_PACKAGE_GLSLSANDBOX_PLAYER is not set
 # BR2_PACKAGE_GNUPLOT is not set
@@ -921,7 +935,10 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_PNGQUANT is not set
 # BR2_PACKAGE_QT5CINEX is not set
 # BR2_PACKAGE_RRDTOOL is not set
-# BR2_PACKAGE_STELLARIUM is not set
+
+#
+# stellarium needs Qt5 and an OpenGL provider
+#
 # BR2_PACKAGE_TESSERACT_OCR is not set
 # BR2_PACKAGE_TINIFIER is not set
 
@@ -939,19 +956,67 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FREERDP is not set
 # BR2_PACKAGE_GRAPHICSMAGICK is not set
 # BR2_PACKAGE_IMAGEMAGICK is not set
-BR2_PACKAGE_LIBGLVND=y
-BR2_PACKAGE_LIBGLVND_DISPATCH_GL=y
-BR2_PACKAGE_PROVIDES_LIBGL="libglvnd"
-BR2_PACKAGE_PROVIDES_LIBEGL="mali-t76x"
-BR2_PACKAGE_PROVIDES_LIBGLES="mali-t76x"
+# BR2_PACKAGE_LIBGLVND is not set
+BR2_PACKAGE_PROVIDES_LIBEGL="rockchip-mali"
+BR2_PACKAGE_PROVIDES_LIBGLES="rockchip-mali"
 
 #
 # linux-fusion needs a Linux kernel to be built
 #
-# BR2_PACKAGE_MESA3D is not set
-BR2_PACKAGE_MESA3D_HEADERS=y
+BR2_PACKAGE_MESA3D=y
+# BR2_PACKAGE_MESA3D_LLVM is not set
+BR2_PACKAGE_MESA3D_DRI3=y
+BR2_PACKAGE_MESA3D_GALLIUM_DRIVER=y
+BR2_PACKAGE_MESA3D_DRIVER=y
+
+#
+# Gallium drivers
+#
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_ETNAVIV is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_FREEDRENO is not set
+BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_LIMA=y
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_NOUVEAU is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_PANFROST is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_SWRAST is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_TEGRA is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_V3D is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_VC4 is not set
+# BR2_PACKAGE_MESA3D_GALLIUM_DRIVER_VIRGL is not set
+
+#
+# Gallium VDPAU state tracker needs X.org and gallium drivers r300, r600, radeonsi or nouveau
+#
+
+#
+# DRI drivers
+#
+# BR2_PACKAGE_MESA3D_DRI_DRIVER_NOUVEAU is not set
+
+#
+# Vulkan drivers
+#
+
+#
+# Off-screen Rendering
+#
+# BR2_PACKAGE_MESA3D_OSMESA_GALLIUM is not set
+
+#
+# OpenGL API Support
+#
+
+#
+# gbm support needs a dri driver or a gallium driver w/ EGL support.
+#
+# BR2_PACKAGE_MESA3D_OPENGL_GLX is not set
+# BR2_PACKAGE_MESA3D_OPENGL_EGL is not set
+# BR2_PACKAGE_MESA3D_OPENGL_ES is not set
+BR2_PACKAGE_PROVIDES_LIBGBM="rockchip-mali"
 # BR2_PACKAGE_OCRAD is not set
-# BR2_PACKAGE_OGRE is not set
+
+#
+# ogre needs X11 and an OpenGL provider
+#
 # BR2_PACKAGE_PSPLASH is not set
 # BR2_PACKAGE_SDL is not set
 # BR2_PACKAGE_SDL2 is not set
@@ -982,7 +1047,6 @@ BR2_PACKAGE_QT5BASE_XML=y
 BR2_PACKAGE_QT5BASE_GUI=y
 BR2_PACKAGE_QT5BASE_WIDGETS=y
 BR2_PACKAGE_QT5BASE_OPENGL=y
-# BR2_PACKAGE_QT5BASE_OPENGL_DESKTOP is not set
 BR2_PACKAGE_QT5BASE_OPENGL_ES2=y
 # BR2_PACKAGE_QT5BASE_OPENGL_LIB is not set
 BR2_PACKAGE_QT5BASE_LINUXFB=y
@@ -1169,7 +1233,10 @@ BR2_PACKAGE_XLIB_XTRANS=y
 # BR2_PACKAGE_XAPP_XDITVIEW is not set
 # BR2_PACKAGE_XAPP_XDM is not set
 # BR2_PACKAGE_XAPP_XDPYINFO is not set
-# BR2_PACKAGE_XAPP_XDRIINFO is not set
+
+#
+# xdriinfo needs an OpenGL backend
+#
 # BR2_PACKAGE_XAPP_XEDIT is not set
 # BR2_PACKAGE_XAPP_XEV is not set
 # BR2_PACKAGE_XAPP_XEYES is not set
@@ -1238,10 +1305,7 @@ BR2_PACKAGE_XDRIVER_XF86_INPUT_LIBINPUT=y
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_DUMMY is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_FBDEV is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_FBTURBO is not set
-
-#
-# xf86-video-glint needs mesa3d
-#
+# BR2_PACKAGE_XDRIVER_XF86_VIDEO_GLINT is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_I128 is not set
 
 #
@@ -1256,41 +1320,22 @@ BR2_PACKAGE_XDRIVER_XF86_INPUT_LIBINPUT=y
 # xf86-video-imx-viv depends on imx-gpu-viv with X11 output
 #
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_MACH64 is not set
-
-#
-# xf86-video-mga needs mesa3d
-#
+# BR2_PACKAGE_XDRIVER_XF86_VIDEO_MGA is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_NEOMAGIC is not set
-
-#
-# xf86-video-nouveau needs mesa3d
-#
+# BR2_PACKAGE_XDRIVER_XF86_VIDEO_NOUVEAU is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_NV is not set
 
 #
 # xf86-video-openchrome needs a DRI driver from mesa3d
 #
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_R128 is not set
-
-#
-# xf86-video-savage needs mesa3d
-#
+# BR2_PACKAGE_XDRIVER_XF86_VIDEO_SAVAGE is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_SILICONMOTION is not set
-
-#
-# xf86-video-sis needs mesa3d
-#
-
-#
-# xf86-video-tdfx needs mesa3d
-#
+# BR2_PACKAGE_XDRIVER_XF86_VIDEO_SIS is not set
+# BR2_PACKAGE_XDRIVER_XF86_VIDEO_TDFX is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_TGA is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_TRIDENT is not set
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_VESA is not set
-
-#
-# xf86-video-vmware needs mesa3d
-#
 # BR2_PACKAGE_XDRIVER_XF86_VIDEO_VOODOO is not set
 
 #
@@ -1367,7 +1412,10 @@ BR2_PACKAGE_XDATA_XBITMAPS=y
 # BR2_PACKAGE_QT_WEBKIT_KIOSK is not set
 # BR2_PACKAGE_RDESKTOP is not set
 # BR2_PACKAGE_SYNERGY is not set
-# BR2_PACKAGE_VTE is not set
+
+#
+# vte needs an OpenGL or an OpenGL-EGL/wayland backend
+#
 # BR2_PACKAGE_WMCTRL is not set
 # BR2_PACKAGE_X11VNC is not set
 # BR2_PACKAGE_XDOTOOL is not set
@@ -1518,7 +1566,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 #
 # mali-driver needs a Linux kernel to be built
 #
-BR2_PACKAGE_MALI_T76X=y
+# BR2_PACKAGE_MALI_T76X is not set
 # BR2_PACKAGE_MBPFAN is not set
 # BR2_PACKAGE_MDADM is not set
 # BR2_PACKAGE_MDEVD is not set
@@ -1556,7 +1604,7 @@ BR2_PACKAGE_MALI_T76X=y
 # BR2_PACKAGE_RASPI_GPIO is not set
 # BR2_PACKAGE_READ_EDID is not set
 # BR2_PACKAGE_RNG_TOOLS is not set
-# BR2_PACKAGE_ROCKCHIP_MALI is not set
+BR2_PACKAGE_ROCKCHIP_MALI=y
 # BR2_PACKAGE_RPI_USERLAND is not set
 # BR2_PACKAGE_RS485CONF is not set
 # BR2_PACKAGE_RTC_TOOLS is not set
@@ -1927,7 +1975,10 @@ BR2_PACKAGE_BAYER2RGB_NEON_ARCH_SUPPORTS=y
 # BR2_PACKAGE_BULLET is not set
 # BR2_PACKAGE_CAIRO is not set
 # BR2_PACKAGE_CAIROMM is not set
-# BR2_PACKAGE_CHIPMUNK is not set
+
+#
+# chipmunk needs an OpenGL backend
+#
 # BR2_PACKAGE_EXEMPI is not set
 # BR2_PACKAGE_EXIV2 is not set
 # BR2_PACKAGE_FLTK is not set
@@ -1950,7 +2001,10 @@ BR2_PACKAGE_FREETYPE=y
 # BR2_PACKAGE_HARFBUZZ is not set
 # BR2_PACKAGE_IJS is not set
 # BR2_PACKAGE_IMLIB2 is not set
-# BR2_PACKAGE_IRRLICHT is not set
+
+#
+# irrlicht needs X11 and an OpenGL provider
+#
 # BR2_PACKAGE_JASPER is not set
 # BR2_PACKAGE_JBIG2DEC is not set
 BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
@@ -1979,16 +2033,28 @@ BR2_PACKAGE_LIBDRM_HAS_ATOMIC=y
 # BR2_PACKAGE_LIBEXIF is not set
 # BR2_PACKAGE_LIBFM is not set
 # BR2_PACKAGE_LIBFM_EXTRA is not set
-# BR2_PACKAGE_LIBFREEGLUT is not set
+
+#
+# libfreeglut depends on X.org and needs an OpenGL backend
+#
 # BR2_PACKAGE_LIBFREEIMAGE is not set
 # BR2_PACKAGE_LIBGDIPLUS is not set
 # BR2_PACKAGE_LIBGEOTIFF is not set
-# BR2_PACKAGE_LIBGLEW is not set
+
+#
+# libglew depends on X.org and needs an OpenGL backend
+#
 # BR2_PACKAGE_LIBGLFW is not set
-# BR2_PACKAGE_LIBGLU is not set
+
+#
+# libglu needs an OpenGL backend
+#
 # BR2_PACKAGE_LIBGTA is not set
 # BR2_PACKAGE_LIBGTK2 is not set
-# BR2_PACKAGE_LIBGTK3 is not set
+
+#
+# libgtk3 needs an OpenGL or an OpenGL-EGL/wayland backend
+#
 # BR2_PACKAGE_LIBMEDIAART is not set
 # BR2_PACKAGE_LIBMNG is not set
 # BR2_PACKAGE_LIBPNG is not set
@@ -2005,8 +2071,9 @@ BR2_PACKAGE_LIBDRM_HAS_ATOMIC=y
 # BR2_PACKAGE_MENU_CACHE is not set
 # BR2_PACKAGE_OPENCV3 is not set
 # BR2_PACKAGE_OPENCV4 is not set
-BR2_PACKAGE_HAS_LIBGL=y
 BR2_PACKAGE_HAS_LIBEGL=y
+BR2_PACKAGE_HAS_LIBGBM=y
+BR2_PACKAGE_LIBGBM_HAS_FEATURE_DMA_BUF=y
 BR2_PACKAGE_HAS_LIBGLES=y
 # BR2_PACKAGE_OPENJPEG is not set
 # BR2_PACKAGE_PANGO is not set
@@ -2015,7 +2082,6 @@ BR2_PACKAGE_PIXMAN=y
 # BR2_PACKAGE_POPPLER is not set
 # BR2_PACKAGE_TIFF is not set
 # BR2_PACKAGE_UNCLUTTER_XFIXES is not set
-BR2_PACKAGE_WAFFLE_SUPPORTS_GLX=y
 BR2_PACKAGE_WAFFLE_SUPPORTS_X11_EGL=y
 # BR2_PACKAGE_WAFFLE is not set
 # BR2_PACKAGE_WAYLAND is not set
@@ -2508,10 +2574,6 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBOSMIUM is not set
 
 #
-# libosmium needs a toolchain w/ C++, wchar, threads, gcc >= 4.7
-#
-
-#
 # libpeas needs python3
 #
 # BR2_PACKAGE_LIBPFM4 is not set
@@ -2564,22 +2626,6 @@ BR2_PACKAGE_PROTOBUF=y
 BR2_PACKAGE_PROTOBUF_C=y
 # BR2_PACKAGE_PROTOZERO is not set
 # BR2_PACKAGE_QHULL is not set
-
-#
-# protobuf needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
-#
-
-#
-# protobuf-c needs a toolchain w/ C++, threads
-#
-
-#
-# protozero needs a toolchain w/ C++, gcc >= 4.7
-#
-
-#
-# qhull needs a toolchain w/ C++, gcc >= 4.4
-#
 # BR2_PACKAGE_QLIBC is not set
 # BR2_PACKAGE_RIEMANN_C_CLIENT is not set
 # BR2_PACKAGE_SHAPELIB is not set

--- a/buildroot-customizations/package/mixxx/Config.in
+++ b/buildroot-customizations/package/mixxx/Config.in
@@ -3,8 +3,6 @@ menuconfig BR2_PACKAGE_MIXXX
     help
         Installs Mixxx, an open-source DJ software.
 
-    select BR2_PACKAGE_LIBGLVND # OpenGL
-    select BR2_PACKAGE_LIBGLVND_DISPATCH_GL # OpenGL
     depends on BR2_PACKAGE_HAS_UDEV # hidapi
     depends on BR2_PACKAGE_QT5
     depends on BR2_PACKAGE_QT5_JSCORE_AVAILABLE # qt5declarative


### PR DESCRIPTION
New attempt at getting hardware accelerated graphics to work for Mixxx via a more modern approach of using mesa3d and its Midgard support implemented via Lima. This requires a rebuild of Qt5 with EGL ES KMS device integration.