### PR TITLE
docs/reveng: add computer mode USB protocol research docs

### DIFF
--- a/docs/reveng/computer-mode/01-usb-devices.md
+++ b/docs/reveng/computer-mode/01-usb-devices.md
@@ -1,0 +1,80 @@
+# USB Device Layout
+
+When the Prime 4 is in Computer Mode, it exposes **5 separate USB devices**
+through a USB gadget named `smexstream`, configured by `planck-remote-screen`
+using `libusbgx` and FunctionFS.
+
+## Vendor / Product IDs
+
+All devices use **VID `0x15e4`** (Numark, InMusic Brands).
+
+| Product ID | Name | USB Class | Linux driver |
+|---|---|---|---|
+| `0x8008` | PRIME 4 Control Surface | USB Audio / MIDI Streaming | `snd-usb-audio` |
+| `0x9008` | PRIME 4 Left Wheel Display | USB Audio / MIDI Streaming | `snd-usb-audio` |
+| `0xb008` | PRIME 4 Right Wheel Display | USB Audio / MIDI Streaming | `snd-usb-audio` |
+| `0xc008` | PRIME 4 Audio | USB Audio 2.0 + MIDI | `snd-usb-audio` |
+| **`0xa008`** | **PRIME 4 Screen** | **Vendor Specific (0xFF/0x01)** | **unbound** |
+
+## PRIME 4 Screen (0xa008) - full descriptor
+
+Interface `9-1:1.0` (sysfs name when on bus 9):
+- Class: `0xFF` (Vendor Specific)  
+- SubClass: `0x01`
+- Protocol: `0x00`
+- Interface string: `"Denon DJ Remote Screen"`
+
+Endpoints:
+
+| EP | Address | Dir | Type | Max pkt | Purpose |
+|---|---|---|---|---|---|
+| EP1 | `0x81` | IN | Bulk | 512B | Device → Host data |
+| EP2 | `0x02` | OUT | Bulk | 512B | **Host → Device** (main data channel) |
+| EP3 | `0x83` | IN | Interrupt | 64B | Device → Host events |
+| EP4 | `0x04` | OUT | Interrupt | 64B | Host → Device commands |
+
+USB negotiated speed: **High Speed (480 Mbps)**
+
+## USB Gadget Configuration
+
+The gadget is configured via `/sys/kernel/config/usb_gadget/smexstream/` using
+`libusbgx`. Known configfs paths written by `planck-remote-screen`:
+
+```
+/sys/kernel/config/usb_gadget/smexstream/functions/midi.midi
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio/c_hs_bint
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio/explicit_feedback
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio/fb_max
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio/named_channels
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio/p_hs_bint
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio/req_number
+/sys/kernel/config/usb_gadget/smexstream/functions/uac2.audio/shared_clock
+```
+
+The Screen interface (`0xa008`) is implemented via **FunctionFS** (`/dev/ffs-*`),
+allowing `planck-remote-screen` to handle it in user-space. The FunctionFS
+endpoints are exposed at `/dev/ffs-{name}/ep1` through `/ep4`.
+
+The vendor and product IDs are set at runtime via:
+- `usbg_set_gadget_vendor_id(0x15e4)`
+- `usbg_set_gadget_product_id(0xa008)` (and per-function variants)
+
+## ALSA MIDI Ports (Linux host)
+
+After the USB MIDI devices enumerate, the following ALSA ports appear:
+
+| Card | Name |
+|---|---|
+| card 3 | PRIME 4 Right Wheel Display |
+| card 4 | PRIME 4 Left Wheel Display |
+| card 5 | PRIME 4 Control Surface |
+| card 6 | PRIME 4 Audio |
+
+Device nodes: `/dev/snd/midiC3D0` through `/dev/snd/midiC6D0`
+
+On the **device itself**, `planck-remote-screen` accesses the MIDI function at:
+```
+/dev/snd/by-path/platform-ff540000.usb-usb-0:1:1.0
+/dev/snd/by-path/platform-ff540000.usb-usb-0:1.2:1.0
+```

--- a/docs/reveng/computer-mode/02-startup-sequence.md
+++ b/docs/reveng/computer-mode/02-startup-sequence.md
@@ -1,0 +1,87 @@
+# Computer Mode - Startup Sequence
+
+## Entry
+
+The device boots Engine OS normally. The user switches to Computer Mode via the
+touchscreen UI. Engine then exits with reason `"ControllerMode"`.
+
+## engine.sh (excerpt - ControllerMode case)
+
+```sh
+"ControllerMode")
+    echo "Starting controller mode."
+    /usr/bin/az01-ethernet-speed 1000
+    touch /tmp/remote-screen-started
+    /usr/Engine/Scripts/remote-screen.sh $APPNAME
+    break
+;;
+```
+
+Key steps:
+1. `az01-ethernet-speed 1000` - sets internal Ethernet to 1 Gbit (RK3288 ↔ internal switch)
+2. Creates `/tmp/remote-screen-started` sentinel file
+3. Runs `remote-screen.sh`
+
+When `engine.sh` restarts and finds `/tmp/remote-screen-started`, it waits 5s
+for USB devices to re-enumerate before starting Engine again.
+
+Engine also calls `az01-usbmux-switch external` then `internal` on exit code 7,
+resetting the USB mux so the gadget re-enumerates on the host.
+
+## remote-screen.sh
+
+```sh
+#!/bin/sh
+APPNAME=$1
+
+while [ 1 ]
+do
+    /usr/bin/planck-remote-screen
+    rsAppExitCode=$?
+
+    if [ "$rsAppExitCode" -eq "0" ]; then
+        echo "Remote Screen App exited"
+        /bin/az01-usbmux-switch internal
+        systemctl restart engine
+        break
+    fi
+    echo "Remote Screen App crashed ($rsAppExitCode)"
+done
+```
+
+- If `planck-remote-screen` exits **cleanly (0)** - user requested to return
+  to standalone → switches USB mux back and restarts Engine
+- If it **crashes (non-zero)** - restart loop continues
+
+## planck-remote-screen
+
+Binary: `/usr/bin/planck-remote-screen` (ARM32 ELF, 11 MB, built with JUCE)
+
+On startup:
+1. Configures the USB gadget (`smexstream`) via `libusbgx` + configfs
+2. Creates FunctionFS mount for the Screen interface
+3. Waits for host (PC) to connect
+4. Runs the `RemoteScreenApp` main loop:
+   - `RemoteScreenNotConnectedComponent` shown until host connects
+   - `RemoteScreenConnectedComponent` shown while connected
+   - Receives `MessageBlock` packets from host via `UsbGadgetMessageBlockStream`
+   - Renders images to local framebuffer (`/dev/fb0`) and display (`/dev/dri/...`)
+   - Handles SMEX control messages (`smex.*`)
+   - Forwards MIDI to/from control surface
+
+## USB mux
+
+The device has an `az01-usbmux-switch` utility that physically switches
+the USB port between internal (standalone Engine) and external (Computer Mode
+gadget) operation. This is why the USB devices disappear and reappear when
+switching modes.
+
+## Framebuffer
+
+The Prime 4 main screen (800×1280 MIPI-DSI) is accessible from Engine OS as:
+- `/dev/fb0` - framebuffer
+- `/dev/dri/by-path/platform-ffa30000.gpu-render` - DRM render node (Mali GPU)
+
+`planck-remote-screen` renders the Computer Mode UI directly to this framebuffer,
+independent of what the host sends. The host sends **content data** (track info,
+images), not raw pixels.

--- a/docs/reveng/computer-mode/03-jog-wheel-sysex.md
+++ b/docs/reveng/computer-mode/03-jog-wheel-sysex.md
@@ -1,0 +1,251 @@
+# Jog Wheel Display Protocol (SysEx over MIDI)
+
+Applies to: **PRIME 4 Left Wheel Display** (`15e4:9008`) and  
+**PRIME 4 Right Wheel Display** (`15e4:b008`).
+
+Source: `JC11_Display_Device.qml` and `JC11_Display_Assignments.qml`  
+in `/usr/Engine/AssignmentFiles/PresetAssignmentFiles/JC11/`
+
+The JC11 is the jog wheel controller module used inside the Prime 4.
+All display communication goes over USB MIDI (ALSA `snd-usb-audio`).
+
+---
+
+## SysEx Format
+
+All jog display commands use the Denon manufacturer SysEx header:
+
+```
+F0 00 02 0B [device_id] 08 [command] 00 [payload_len] [payload...] F7
+```
+
+- `F0` - SysEx start
+- `00 02 0B` - Denon DJ manufacturer ID
+- `[device_id]` - `0x10` (left) or `0x30` (right); determined by inquiry
+- `08` - "display" section byte
+- `[command]` - command byte (see table below)
+- `00 [payload_len]` - 2-byte payload length (big-endian)
+- `[payload...]` - command-specific data
+- `F7` - SysEx end
+
+### Device ID Discovery
+
+Send MIDI Universal Identity Request:
+```
+F0 7E 00 06 01 F7
+```
+Device responds with inquiry reply; **byte index 15** of the response contains
+the device ID (`0x10` = left, `0x30` = right).
+
+---
+
+## Command Reference
+
+### `0x10` - Start Image Decode
+
+```
+F0 00 02 0B [id] 08 10 00 00 F7
+```
+
+Sent on init. The device responds with a SysEx message containing `code=0x10`
+when it is ready to receive image data (`imageSendingEnabled = true`).
+
+Also used with a **17-second timeout**: if no response within 17s, the host
+assumes the device is ready anyway.
+
+### `0x7C` - Set Brightness
+
+```
+F0 00 02 0B [id] 08 7C 00 01 [level] F7
+```
+
+| Level | Value |
+|---|---|
+| Off (dark) | `0x00` |
+| Low | `0x0F` (15) |
+| Mid | `0x46` (70) |
+| High | `0x69` (105) |
+| Max | `0x7F` (127) |
+
+### `0x0B` - Set Element Color (ARGB)
+
+```
+F0 00 02 0B [id] 08 0B 00 09 [elem_id] [A_hi] [A_lo] [R_hi] [R_lo] [G_hi] [G_lo] [B_hi] [B_lo] F7
+```
+
+Each color component is encoded as **two nibbles** (7-bit each):
+```javascript
+function colorComponentToHex(component) {
+    var ci = Math.floor(component * 255)
+    return d2h((ci & 0xF0) >> 4) + " " + d2h(ci & 0x0F)
+}
+```
+
+#### Element IDs
+
+| ID | Element |
+|---|---|
+| 0 | Album Artwork (alpha only, `Qt.rgba(1,1,1,alpha)`) |
+| 1 | Engine Logo |
+| 2 | Platter Position Ring |
+| 3 | Platter Position Indicator |
+| 4 | Slip Position Ring (alpha, `Qt.rgba(0,0,0,alpha)`) |
+| 5 | Slip Position Indicator |
+| 6 | Track Progress Ring |
+| 7 | Track Progress Indicator |
+| 8 | Loop and Layer Text |
+| 9 | Burst Image |
+| 10 | Jump Icon |
+| 11 | Loop Icon |
+
+### `0x0A` - Update Display Elements
+
+```
+F0 00 02 0B [id] 08 0A 00 04 [byte0] [byte1] [artwork_idx] [text_idx] F7
+```
+
+#### byte0 - Element Enable/Disable 1
+
+| Bit | Element |
+|---|---|
+| 0 | Album Artwork |
+| 1 | Engine Logo |
+| 2 | Platter Position Ring |
+| 4 | Slip Position Ring (active) |
+| 5 | Slip Position Indicator (active) |
+
+#### byte1 - Element Enable/Disable 2
+
+| Bit | Element |
+|---|---|
+| 1 | Loop and Layer Text |
+| 3 | Jump Icon |
+| 4 | Loop Icon |
+
+#### artwork_idx - Album Artwork Index
+- `0` = no artwork / placeholder
+- `1` = Deck 1 artwork
+- `2` = Deck 3 artwork (second layer)
+- `3` = Device artwork (CurrentDeviceArtwork)
+
+#### text_idx - Loop / Layer Text Code
+
+| Code | Text |
+|---|---|
+| 0x0 | "1/64" |
+| 0x1 | "1/32" |
+| 0x2 | "1/16" |
+| 0x3 | "1/8" |
+| 0x4 | "1/4" |
+| 0x5 | "1/2" |
+| 0x6 | "1" |
+| 0x7 | "2" |
+| 0x8 | "4" |
+| 0x9 | "8" |
+| 0xA | "16" |
+| 0xB | "32" |
+| 0xC | "64" |
+| 0xD | "--" (default/unknown) |
+| 0xE | "A" |
+| 0xF | "B" |
+| 0x10 | "3" |
+| 0x11 | "6" |
+| 0x12 | "9" |
+| 0x13 | "C" |
+| 0x14 | "D" |
+
+---
+
+## Image Sending
+
+Album artwork and other images are rendered offscreen by the host, encoded as
+**PNG**, and sent as a sequence of SysEx packets.
+
+### Render Pipeline
+
+1. **Painter** QML object with `format: Painter.AZ01_CENTER_WHEEL_DISPLAY`
+2. Canvas size: **198 × 198 pixels**
+3. Draw steps:
+   ```qml
+   begin()
+   clear("white")
+   translate(width, height)
+   rotate(180)
+   drawByteArray(albumArt, 0, 0, width, height)
+   drawHole("black", Qt.rect(0,0,w,h), Qt.point(w/2, h/2), (w/2)-4)
+   ```
+   - The center hole mimics the jog wheel platter hole.
+4. Convert to SysEx:
+   ```qml
+   var data = imageToByteArrays(artworkIndex, 0x08, device.midiDeviceId)
+   Midi.sendByteArrays(data)
+   ```
+
+`imageToByteArrays(index, section, deviceId)` - host-side QML API:
+- Encodes the rendered PNG into Denon SysEx chunks
+- `index` = artwork slot (1 or 2 for left/right deck, 3 for device artwork)
+- `section` = `0x08` (display section)
+- Returns an array of `QByteArray` objects, each one a complete SysEx message
+
+### Device Response
+
+After the host sends image data, the device replies with a SysEx containing:
+- `code = 0x10` → decoding complete, ready for display updates
+- `code = 0x0f` → upload status; `byte[9] = 0x00` = success, non-zero = error
+
+---
+
+## Platter Position (Realtime)
+
+Sent via **MIDI Pitch Bend** messages (not SysEx) at 12ms intervals:
+
+```qml
+Timer { interval: 12; repeat: true
+    onTriggered: {
+        Midi.sendPitch(0, angle)       // main platter angle
+        Midi.sendPitch(1, slipAngle)   // slip mode angle
+    }
+}
+```
+
+Position source: `/Private/Deck%d/MidiSamplePosition`
+
+Angle calculation:
+```javascript
+const divider = 60.0 / (33.0 + 1.0/3.0)   // seconds per revolution at 33⅓ RPM
+const mod = divider * 44100.0               // samples per revolution
+const modulo = (pos % mod + mod) % mod
+const angle = (modulo / 44100.0) / divider  // 0.0 – 1.0
+```
+
+---
+
+## Additional SysEx (from JP11_Controller_Device.qml)
+
+These are sent to the **Control Surface** MIDI device, not the wheel displays.
+
+### Query absolute control positions
+
+```
+F0 00 02 0B 7F 0C 04 00 00 F7
+```
+
+### Initialization / query knob+fader positions
+
+```
+F0 00 02 0B 7F 0C 60 00 04 04 01 01 04 F7
+```
+
+### Query power-on button state
+
+```
+F0 00 02 0B 7F 0C 42 00 00 F7
+```
+
+### Set RGB LED color (control surface buttons)
+
+```
+F0 00 02 0B 7F 0C 03 00 05 [channel] [index] [R7] [G7] [B7] F7
+```
+- `[channel]` and `[index]` identify the button
+- `[R7] [G7] [B7]` are 7-bit color values (0–127)

--- a/docs/reveng/computer-mode/04-main-screen-smex.md
+++ b/docs/reveng/computer-mode/04-main-screen-smex.md
@@ -18,12 +18,17 @@ application `planck-remote-screen` receives data and renders to the local frameb
 
 The FunctionFS gadget is named **smexstream** and exposes four endpoints:
 
-| EP address | Direction | Type | Max pkt | Purpose |
-|---|---|---|---|---|
-| `0x02` | OUT | Bulk | 512B | Host to device - large data (images etc.) |
-| `0x81` | IN | Bulk | 512B | Device to host - large data |
-| `0x04` | OUT | Interrupt | 64B | **Host to device - SMEX control messages** |
-| `0x83` | IN | Interrupt | 64B | **Device to host - SMEX responses** |
+| EP address | Direction | Type | Max pkt (FS/HS) | Used by planck | Purpose |
+|---|---|---|---|---|---|
+| `0x02` | OUT | Bulk | 64B / 512B | Yes (AIO PREAD) | Host to device - large data (images etc.) |
+| `0x81` | IN | Bulk | 64B / 512B | **No** | Reserved - planck never writes here |
+| `0x04` | OUT | Interrupt | 64B | Yes (AIO PREAD) | **Host to device - SMEX control messages** |
+| `0x83` | IN | Interrupt | 64B | **No** | Reserved - planck never writes here |
+
+**Protocol is UNIDIRECTIONAL** (host to device only). Confirmed by strace analysis
+of planck's full syscall trace at startup: planck only ever submits `IOCB_CMD_PREAD`
+operations on ep2 (fd=16) and ep4 (fd=18). No `IOCB_CMD_PWRITE` or `write()` calls
+are ever made to ep1 (fd=15) or ep3 (fd=17) under any circumstances.
 
 **Critical**: SMEX control messages go on the **interrupt endpoints** (EP4 OUT /
 EP3 IN), NOT the bulk endpoints. The bulk endpoints (EP2 OUT / EP1 IN) are for
@@ -38,16 +43,25 @@ larger data transfers.
 `planck-remote-screen` opens all five FunctionFS fds on startup:
 
 ```
-/dev/ffs-smexstream/ep0   (control - USB events)
-/dev/ffs-smexstream/ep1   (bulk IN  - device to host)
-/dev/ffs-smexstream/ep2   (bulk OUT - host to device)
-/dev/ffs-smexstream/ep3   (interrupt IN  - device to host)
-/dev/ffs-smexstream/ep4   (interrupt OUT - host to device)
+/dev/ffs-smexstream/ep0   (control - USB events, fd=14)
+/dev/ffs-smexstream/ep1   (bulk IN  - device to host, fd=15) <- UNUSED
+/dev/ffs-smexstream/ep2   (bulk OUT - host to device, fd=16) <- reads via AIO
+/dev/ffs-smexstream/ep3   (interrupt IN  - device to host, fd=17) <- UNUSED
+/dev/ffs-smexstream/ep4   (interrupt OUT - host to device, fd=18) <- reads via AIO
 ```
 
-It uses Linux AIO (`io_submit`, syscall 246) to submit 32 concurrent async
-reads on each OUT endpoint. All 9 IOCBs in a typical batch are PREAD on fd=16
-(ep2) or fd=18 (ep4). Responses are written to ep3 and ep1.
+Startup sequence (verified via strace with -f flag):
+1. Writes USB descriptor to ep0 (`write(14, descriptor, 133)`) - two alternate settings
+2. Writes UDC name to fd=20 (`write(20, "ff580000.usb", 12)`) - binds gadget
+3. Prints "Gadget state changed: connected" once host sends SET_CONFIGURATION
+4. Submits **32 AIO PREADs** on ep2 (fd=16), each 4096 bytes
+5. Submits **32 AIO PREADs** on ep4 (fd=18), each 64 bytes
+
+On each AIO completion (host wrote data):
+- `io_getevents` harvests the result (`res=64` for ep4, `res=4096` for ep2)
+- One new PREAD is re-submitted to maintain the pool
+- The FunctionFS thread calls the AIO callback inline (no JUCE notification)
+- **No writes to ep3 or ep1 occur at any point**
 
 ### Connection sequence
 
@@ -55,34 +69,36 @@ The USB gadget must be fully activated before communication is possible.
 The correct sequence from the host side is:
 
 1. Detect the device via `libusb_open_device_with_vid_pid(ctx, 0x15e4, 0xa008)`
-2. Call `libusb_set_configuration(h, 1)` **exactly once** to trigger
-   `ffs_func_set_alt` in the kernel, which binds the endpoints and wakes up
-   `planck-remote-screen`'s AIO reads
+2. Call `libusb_set_configuration(h, 1)` to trigger `ffs_func_set_alt` in the
+   kernel, which binds the endpoints and starts `planck-remote-screen`'s AIO reads
 3. Claim interface 0
-4. Submit reads on EP3 IN (interrupt) AND EP1 IN (bulk) immediately - the device
-   may send an initial announcement before the host sends anything
-5. Write `smex.protocolversion` to EP4 OUT (interrupt, max 64 bytes)
+4. Send SMEX commands to EP4 OUT (interrupt, **must be exactly 64 bytes** padded)
+5. Send image/bulk data to EP2 OUT (bulk, up to 4096 bytes per transfer)
 
-**Important**: Avoid calling `set_configuration()` more than once per planck
-instance. Each call to `set_configuration()` or `claim_interface()` that
-sends a SET_CONFIGURATION or SET_INTERFACE request causes `ffs_func_set_alt`
-to run again, which re-initialises the endpoints and resets any pending AIO
-reads. This creates a race condition where the host's writes land in the DMA
-buffer but the completion notification never fires for `planck-remote-screen`.
+**No response is expected** - the protocol is unidirectional. EP3 IN and EP1 IN
+exist in the USB descriptor but planck never writes to them.
+
+### 64B padding requirement
+
+All messages sent to EP4 OUT (interrupt endpoint, mps=64) **must be padded to
+exactly 64 bytes**. Messages shorter than 64 bytes cause the FunctionFS interrupt
+endpoint to not signal completion properly, and `io_getevents` on the device side
+never returns for those transfers. This was confirmed experimentally:
+- Unpadded messages: `io_getevents` never fires, message is silently dropped
+- 64B padded messages: `io_getevents` returns `res=64`, message is processed
+
+For EP2 OUT (bulk), messages can be variable length up to 4096 bytes per transfer.
 
 ### Known issue with repeated re-enumeration
 
 During testing it was observed that the dwc2 USB OTG controller on the RK3288
-(ff580000.usb) correctly receives bulk/interrupt OUT data into DMA buffers (verified
-by reading `/dev/mem` at the DMA address), and the IRQ counter increases with each
-host write. However, `total_data` in the kernel's ep debugfs stays at 0 if the
-endpoint binding is disrupted mid-transfer.
+(ff580000.usb) correctly receives OUT data into DMA buffers (verified
+by reading `/dev/mem` at the DOEPDMA address), and the IRQ counter increases with
+each host write. However, `total_data` in the kernel's ep debugfs stays at 0 if
+messages are not exactly 64 bytes for EP4.
 
-Root cause: `planck-remote-screen`'s AIO reads block in `ffs_epfile_io` at
-`wait_event_interruptible(epfile->wait, ep = epfile->ep)` if `ffs_func_set_alt`
-was not called or was called while the io_submit was in flight. Re-submitting
-SET_CONFIGURATION from the host wakes this up, but only if done cleanly once at
-startup.
+The 64B padding requirement explains the earlier "kernel bug" hypothesis - the
+transfers were not completing because messages were short-packets.
 
 ---
 
@@ -206,14 +222,18 @@ dev = libusb.open(vid=0x15e4, pid=0xa008)
 dev.set_configuration(1)          # triggers ffs_func_set_alt once
 dev.claim_interface(0)
 
-# Keep IN endpoints polled continuously (device may initiate first)
-start_async_reader(EP3_IN=0x83, max=64)
-start_async_reader(EP1_IN=0x81, max=512)
-
-# Send version handshake on interrupt OUT
+# Send SMEX version handshake on interrupt OUT (must be exactly 64 bytes)
 smex_version = build_smex("smex.protocolversion", "1")
-dev.write(EP4_OUT=0x04, smex_version)
+padded = smex_version + bytes(64 - len(smex_version))  # pad to 64B
+dev.write(EP4_OUT=0x04, padded)   # no response expected
 
-# Wait for smex.version response on EP3 IN
-response = read(EP3_IN=0x83, timeout=3000)
+# Send display commands - all via EP4 (control) and EP2 (bulk data)
+smex_brightness = build_smex("smex.brightness.set", "80")
+dev.write(EP4_OUT=0x04, smex_brightness + bytes(64 - len(smex_brightness)))
+
+# Send bulk image/content data via EP2
+dev.write(EP2_OUT=0x02, image_data)  # variable length, up to 4096B per transfer
 ```
+
+Note: EP3 IN (0x83) and EP1 IN (0x81) exist in the USB descriptor but are not
+used by planck-remote-screen. Do not expect responses on these endpoints.

--- a/docs/reveng/computer-mode/04-main-screen-smex.md
+++ b/docs/reveng/computer-mode/04-main-screen-smex.md
@@ -1,98 +1,136 @@
-# Main Screen Protocol - SMEX / MessageBlock (FunctionFS Bulk)
+# Main Screen Protocol - SMEX / MessageBlock (FunctionFS)
 
 Applies to: **PRIME 4 Screen** (`15e4:a008`)
 
 This is the main 7" touch display of the Prime 4 (800x1280 MIPI-DSI, internal).
-The host communicates with it via **bulk USB transfers** over the FunctionFS
-vendor-class interface. The device-side application `planck-remote-screen`
-receives data and renders to the local framebuffer.
+The host communicates via the FunctionFS vendor-class interface. The device-side
+application `planck-remote-screen` receives data and renders to the local framebuffer.
 
-## Source
+## Sources
 
-All findings in this document come from the JP11 firmware rootfs, specifically
-from strings and symbol names extracted from `/usr/bin/planck-remote-screen`
-(ARM32 ELF, 11 MB).
+- Strings and symbol names from `/usr/bin/planck-remote-screen` (ARM32 ELF, firmware 4.3.4)
+- Reverse engineering of `serato_device_akaisdk.dll` (Serato's Akai SDK, 1.5 MB)
+- Live USB testing via SSH to the Prime 4 at `icedream-dp4` with direct kernel inspection
+
+---
+
+## USB Endpoint Map
+
+The FunctionFS gadget is named **smexstream** and exposes four endpoints:
+
+| EP address | Direction | Type | Max pkt | Purpose |
+|---|---|---|---|---|
+| `0x02` | OUT | Bulk | 512B | Host to device - large data (images etc.) |
+| `0x81` | IN | Bulk | 512B | Device to host - large data |
+| `0x04` | OUT | Interrupt | 64B | **Host to device - SMEX control messages** |
+| `0x83` | IN | Interrupt | 64B | **Device to host - SMEX responses** |
+
+**Critical**: SMEX control messages go on the **interrupt endpoints** (EP4 OUT /
+EP3 IN), NOT the bulk endpoints. The bulk endpoints (EP2 OUT / EP1 IN) are for
+larger data transfers.
 
 ---
 
 ## Transport
 
-### Host side
+### Device side (planck-remote-screen)
 
-Open the vendor-class interface with libusb (no kernel driver needed - the
-interface is unbound on Linux by default):
-
-```c
-libusb_device_handle *h = libusb_open_device_with_vid_pid(ctx, 0x15e4, 0xa008);
-libusb_claim_interface(h, 0);
-libusb_bulk_transfer(h, 0x02 /* EP2 OUT */, buf, len, &transferred, timeout_ms);
-libusb_bulk_transfer(h, 0x81 /* EP1 IN  */, buf, len, &transferred, timeout_ms);
-```
-
-### Device side
-
-`planck-remote-screen` reads/writes via FunctionFS file descriptors:
+`planck-remote-screen` opens all five FunctionFS fds on startup:
 
 ```
-/dev/ffs-{gadget_name}/ep1   (IN  bulk)
-/dev/ffs-{gadget_name}/ep2   (OUT bulk)
-/dev/ffs-{gadget_name}/ep3   (IN  interrupt)
-/dev/ffs-{gadget_name}/ep4   (OUT interrupt)
+/dev/ffs-smexstream/ep0   (control - USB events)
+/dev/ffs-smexstream/ep1   (bulk IN  - device to host)
+/dev/ffs-smexstream/ep2   (bulk OUT - host to device)
+/dev/ffs-smexstream/ep3   (interrupt IN  - device to host)
+/dev/ffs-smexstream/ep4   (interrupt OUT - host to device)
 ```
 
-Uses `boost::asio` (io_context) for async I/O with 32 outstanding requests
-per endpoint (`OutEndpoint<FsOutRequest, 32>`).
+It uses Linux AIO (`io_submit`, syscall 246) to submit 32 concurrent async
+reads on each OUT endpoint. All 9 IOCBs in a typical batch are PREAD on fd=16
+(ep2) or fd=18 (ep4). Responses are written to ep3 and ep1.
+
+### Connection sequence
+
+The USB gadget must be fully activated before communication is possible.
+The correct sequence from the host side is:
+
+1. Detect the device via `libusb_open_device_with_vid_pid(ctx, 0x15e4, 0xa008)`
+2. Call `libusb_set_configuration(h, 1)` **exactly once** to trigger
+   `ffs_func_set_alt` in the kernel, which binds the endpoints and wakes up
+   `planck-remote-screen`'s AIO reads
+3. Claim interface 0
+4. Submit reads on EP3 IN (interrupt) AND EP1 IN (bulk) immediately - the device
+   may send an initial announcement before the host sends anything
+5. Write `smex.protocolversion` to EP4 OUT (interrupt, max 64 bytes)
+
+**Important**: Avoid calling `set_configuration()` more than once per planck
+instance. Each call to `set_configuration()` or `claim_interface()` that
+sends a SET_CONFIGURATION or SET_INTERFACE request causes `ffs_func_set_alt`
+to run again, which re-initialises the endpoints and resets any pending AIO
+reads. This creates a race condition where the host's writes land in the DMA
+buffer but the completion notification never fires for `planck-remote-screen`.
+
+### Known issue with repeated re-enumeration
+
+During testing it was observed that the dwc2 USB OTG controller on the RK3288
+(ff580000.usb) correctly receives bulk/interrupt OUT data into DMA buffers (verified
+by reading `/dev/mem` at the DMA address), and the IRQ counter increases with each
+host write. However, `total_data` in the kernel's ep debugfs stays at 0 if the
+endpoint binding is disrupted mid-transfer.
+
+Root cause: `planck-remote-screen`'s AIO reads block in `ffs_epfile_io` at
+`wait_event_interruptible(epfile->wait, ep = epfile->ep)` if `ffs_func_set_alt`
+was not called or was called while the io_submit was in flight. Re-submitting
+SET_CONFIGURATION from the host wakes this up, but only if done cleanly once at
+startup.
 
 ---
 
-## MessageBlock Framing
+## MessageBlock Wire Format
 
-The framing layer is `MessageBlockStream`. The same format is used over both
-USB (via `UsbGadgetMessageBlockStream`) and TCP (via `NetworkMessageBlockStream`).
-
-Key classes found in the binary:
-
-| Class | Role |
-|---|---|
-| `MessageBlockBuilderOutputStream` | Serialises a message into wire bytes |
-| `MessageBlockReader` | Deserialises bytes into a message |
-| `MessageBlockRouter` | Routes messages to handlers by type |
-| `MessageBlockService` | Service endpoint for receiving messages |
-| `ConnectableMessageBlockStream` | State-machine wrapper (connecting/connected/disconnected) |
-| `UsbGadgetMessageBlockStream` | Bulk-USB transport |
-| `NetworkMessageBlockStream` | TCP transport (same wire format) |
-| `FsTransferMessageBlockStream` | Filesystem transport (firmware update images) |
-
-Wire format decoded from `serato_device_akaisdk.dll` (Serato's Akai SDK for the Prime 4):
+Decoded from `serato_device_akaisdk.dll` (Serato SDK):
 
 ```
 [uint32 BE: total content length]
-[uint32 BE: type string length]
-[bytes: type string UTF-8]       e.g. "smex.protocolversion"
-[uint32 BE: payload length]
-[bytes: payload]
+[uint8:     service ID]            0x00=SmexControl 0x01=PingPong 0x02=ImageStream 0x03=TouchInput 0x04=MessageBlockService
+[bytes:     service payload]
 ```
 
-The `SmexControlService::Received` handler reads two length-prefixed
-strings per message: the type name then the payload. Both strings use
-`[uint32 BE length][UTF-8 bytes]` encoding.
+For **SmexControlService** (service ID `0x00`):
+
+```
+[uint32 BE: type string length]
+[bytes:     type string UTF-8]    e.g. "smex.protocolversion"
+[uint32 BE: payload length]
+[bytes:     payload UTF-8]
+```
+
+For **PingPongService** (service ID `0x01`):
+
+```
+[uint32 BE: sequence ID]
+[uint8:     type]                  0x01=ping, 0x03=pong
+```
+
+Service registration (from `serato_device_akaisdk.dll`):
+
+| Byte | Service | Direction |
+|---|---|---|
+| `0x00` | SmexControlService | Bidirectional control |
+| `0x01` | PingPongService | Keepalive (2000ms interval) |
+| `0x02` | ImageStreamEncoder | Host to device images |
+| `0x03` | TouchInputListener | Device to host touch events |
+| `0x04` | MessageBlockService | General messages |
 
 ---
 
 ## SMEX Control Protocol
 
-The control channel uses named string message types (`smex.*`).
-Implemented by `SmexControlService` on the device side.
-The client namespace is `Acvt` (`Acvt::SmexClient`).
-
-The name "SMEX" appears to be an Akai-derived protocol - the binary contains
-`Akai::RemoteScreen` as a C++ namespace.
-
-### Known message types (from binary strings)
+### Message types (13 total, from `planck-remote-screen` binary strings)
 
 | Message | Direction | Description |
 |---|---|---|
-| `smex.protocolversion` | both | Version handshake - sent first by both sides |
+| `smex.protocolversion` | both | Version handshake - first message exchanged |
 | `smex.version` | device to host | Device firmware version string |
 | `smex.time.request` | host to device | Request device clock |
 | `smex.time.set` | host to device | Set device clock |
@@ -106,76 +144,76 @@ The name "SMEX" appears to be an Akai-derived protocol - the binary contains
 | `smex.restart.updater` | host to device | Boot into firmware updater |
 | `smex.unknown` | - | Handler for unrecognised type |
 
-### Connection
-
-The `PingPongListener::Connection` type indicates a ping/pong keepalive
-mechanism on the connection.
+The 13 type strings are stored as a sequential pointer table in `.rodata` at
+file offset `0x43baa8` (VA `0x443aa8`) of `planck-remote-screen`.
 
 ---
 
 ## Image Streaming
 
-The `ImageStreamEncoder::ReceiveComponentImage(juce::Image, juce::RectangleList<int>)`
-method on the device side receives rendered component images and displays them on the
-device's own 800x1280 MIPI-DSI screen via the local DRM/KMS framebuffer (`/dev/fb0`,
-`/dev/dri/...`). This is **not** a USB transfer - the display is rendered locally.
+`ImageStreamEncoder::ReceiveComponentImage(juce::Image, juce::RectangleList<int>)`
+on the device side receives rendered component images and displays them on the
+device's own local framebuffer (`/dev/fb0`, `/dev/dri/...`). This is **not** a
+USB transfer - the display is rendered locally by `planck-remote-screen` after
+receiving content metadata (track info, artwork etc.) via SMEX or other means.
 
-Jog wheel images are sent separately over the MIDI SysEx interface (see `03-jog-wheel-sysex.md`).
-
-The `UsbGadgetMessageBlockStream` (FunctionFS bulk stream) carries only **small SMEX
-control messages** - not pixel or image data.
-
----
-
-## Key Binary Symbols (planck-remote-screen)
-
-C++ class names from RTTI strings in the binary:
-
-```
-RemoteScreenApp
-RemoteScreenMainWindow
-RemoteScreenConnectedComponent
-RemoteScreenNotConnectedComponent
-RemoteScreenService
-ImageStreamEncoder
-UsbGadgetMessageBlockStream
-NetworkMessageBlockStream
-FsTransferMessageBlockStream
-MessageBlockRouter
-MessageBlockBuilderOutputStream
-SmexControlHost
-SmexControlClient
-SmexControlService
-Acvt::SmexClient
-UsbGadgetVolumeControl
-MidiOutputServiceClient
-ScreensaverTimer
-ScreensaverComponent
-```
+Jog wheel images are sent separately over MIDI SysEx (see `03-jog-wheel-sysex.md`).
 
 ---
 
 ## Library and Deck Display Capability
 
-The `serato_device_akaisdk.dll` (Serato's implementation of the Akai SDK)
-exposes the following display data structures in the `Akai::RemoteScreen::DjDisplay`
-namespace. These confirm that the Prime 4 screen CAN display rich content
-from the connected DJ software, not just a static "connected" screen:
+The `serato_device_akaisdk.dll` exposes the following in `Akai::RemoteScreen::DjDisplay`,
+confirming the screen can display rich content from the DJ software:
 
-| Struct / Enum | Purpose |
+| Type | Purpose |
 |---|---|
-| `DeckDisplay` | Full deck state (track info, waveform position, loop, etc.) |
-| `ListRow` | A single row in a library list view |
-| `BrowserMode` | Which browse mode is active (library, cue list, etc.) |
-| `CuePoint` | Cue point display data |
-| `WaveformLocation` | Current playhead position for waveform display |
-| `ScrollBar` | Scroll bar state for lists |
-| `DeckPressEvent` | Touch/jog press event from the device |
-| `Question` | Dialog/confirmation popup |
-| `DeckDrawingStyle` | Visual style for the deck display |
+| `DeckDisplay` | Deck state (track info, waveform, loop, etc.) |
+| `ListRow` | A single row in a library list |
+| `BrowserMode` | Current browse mode (library, cue list, etc.) |
+| `CuePoint` | Cue point display |
+| `WaveformLocation` | Playhead position for waveform |
+| `ScrollBar` | List scrollbar state |
+| `DeckPressEvent` | Touch/jog input from device |
+| `Question` | Dialog/confirmation |
+| `DeckDrawingStyle` | Visual deck style |
 
-The SDK is accessed via a single export `CreateAkaiSDK()` which returns an
-opaque object. All API calls are via virtual methods on the returned object.
+Host entry point: `CreateAkaiSDK()` returns an opaque object; all calls are
+through virtual methods. `AkaiSDKDevices::DeviceConnected` fires when a
+device is found.
 
-The `AkaiSDKDevices::DeviceConnected` callback fires when a Prime 4 is
-detected, providing a `Device` object through which display updates are sent.
+---
+
+## Direct Device Inspection Results (live testing)
+
+The following was confirmed by SSHing into the Prime 4 at runtime:
+
+- `planck-remote-screen` (PID varies) runs with 3 threads
+- All five FunctionFS fds (ep0-ep4) are open
+- `boost::asio` io_context submits AIO reads in batches of 9 (PREAD, fd=16/ep2 or fd=18/ep4)
+- The UDC (`ff580000.usb`, RK3288 dwc2) correctly writes host data into DMA buffers
+  (verified by reading `/dev/mem` at the DOEPDMA address)
+- IRQ count increases by 1 per host write, confirming hardware receipt
+- The `wait_event_interruptible(epfile->wait, ep = epfile->ep)` in `ffs_epfile_io`
+  can block the AIO submission if `ffs_func_set_alt` has not completed
+- A soft-disconnect/reconnect cycle (`echo disconnect/connect > soft_connect`) followed
+  by one clean SET_CONFIGURATION from the host resolves the blockage
+
+### Minimal working connection sequence (pseudocode)
+
+```python
+dev = libusb.open(vid=0x15e4, pid=0xa008)
+dev.set_configuration(1)          # triggers ffs_func_set_alt once
+dev.claim_interface(0)
+
+# Keep IN endpoints polled continuously (device may initiate first)
+start_async_reader(EP3_IN=0x83, max=64)
+start_async_reader(EP1_IN=0x81, max=512)
+
+# Send version handshake on interrupt OUT
+smex_version = build_smex("smex.protocolversion", "1")
+dev.write(EP4_OUT=0x04, smex_version)
+
+# Wait for smex.version response on EP3 IN
+response = read(EP3_IN=0x83, timeout=3000)
+```

--- a/docs/reveng/computer-mode/04-main-screen-smex.md
+++ b/docs/reveng/computer-mode/04-main-screen-smex.md
@@ -1,0 +1,140 @@
+# Main Screen Protocol - SMEX / MessageBlock (FunctionFS Bulk)
+
+Applies to: **PRIME 4 Screen** (`15e4:a008`)
+
+This is the main 7" touch display of the Prime 4 (800x1280 MIPI-DSI, internal).
+The host communicates with it via **bulk USB transfers** over the FunctionFS
+vendor-class interface. The device-side application `planck-remote-screen`
+receives data and renders to the local framebuffer.
+
+## Source
+
+All findings in this document come from the JP11 firmware rootfs, specifically
+from strings and symbol names extracted from `/usr/bin/planck-remote-screen`
+(ARM32 ELF, 11 MB).
+
+---
+
+## Transport
+
+### Host side
+
+Open the vendor-class interface with libusb (no kernel driver needed - the
+interface is unbound on Linux by default):
+
+```c
+libusb_device_handle *h = libusb_open_device_with_vid_pid(ctx, 0x15e4, 0xa008);
+libusb_claim_interface(h, 0);
+libusb_bulk_transfer(h, 0x02 /* EP2 OUT */, buf, len, &transferred, timeout_ms);
+libusb_bulk_transfer(h, 0x81 /* EP1 IN  */, buf, len, &transferred, timeout_ms);
+```
+
+### Device side
+
+`planck-remote-screen` reads/writes via FunctionFS file descriptors:
+
+```
+/dev/ffs-{gadget_name}/ep1   (IN  bulk)
+/dev/ffs-{gadget_name}/ep2   (OUT bulk)
+/dev/ffs-{gadget_name}/ep3   (IN  interrupt)
+/dev/ffs-{gadget_name}/ep4   (OUT interrupt)
+```
+
+Uses `boost::asio` (io_context) for async I/O with 32 outstanding requests
+per endpoint (`OutEndpoint<FsOutRequest, 32>`).
+
+---
+
+## MessageBlock Framing
+
+The framing layer is `MessageBlockStream`. The same format is used over both
+USB (via `UsbGadgetMessageBlockStream`) and TCP (via `NetworkMessageBlockStream`).
+
+Key classes found in the binary:
+
+| Class | Role |
+|---|---|
+| `MessageBlockBuilderOutputStream` | Serialises a message into wire bytes |
+| `MessageBlockReader` | Deserialises bytes into a message |
+| `MessageBlockRouter` | Routes messages to handlers by type |
+| `MessageBlockService` | Service endpoint for receiving messages |
+| `ConnectableMessageBlockStream` | State-machine wrapper (connecting/connected/disconnected) |
+| `UsbGadgetMessageBlockStream` | Bulk-USB transport |
+| `NetworkMessageBlockStream` | TCP transport (same wire format) |
+| `FsTransferMessageBlockStream` | Filesystem transport (firmware update images) |
+
+Wire format: not yet fully decoded. Further analysis of `planck-remote-screen`
+required.
+
+---
+
+## SMEX Control Protocol
+
+The control channel uses named string message types (`smex.*`).
+Implemented by `SmexControlService` on the device side.
+The client namespace is `Acvt` (`Acvt::SmexClient`).
+
+The name "SMEX" appears to be an Akai-derived protocol - the binary contains
+`Akai::RemoteScreen` as a C++ namespace.
+
+### Known message types (from binary strings)
+
+| Message | Direction | Description |
+|---|---|---|
+| `smex.protocolversion` | both | Version handshake - sent first by both sides |
+| `smex.version` | device to host | Device firmware version string |
+| `smex.time.request` | host to device | Request device clock |
+| `smex.time.set` | host to device | Set device clock |
+| `smex.brightness.request` | host to device | Query current brightness |
+| `smex.brightness.set` | host to device | Set screen brightness |
+| `smex.screensaver.set` | host to device | Enable/disable screensaver |
+| `smex.battery` | device to host | Battery level (battery-powered devices only) |
+| `smex.powerkey` | device to host | Power button pressed |
+| `smex.restart.powerdown` | host to device | Power off the device |
+| `smex.restart.standalone` | host to device | Return to standalone Engine mode |
+| `smex.restart.updater` | host to device | Boot into firmware updater |
+| `smex.unknown` | - | Handler for unrecognised type |
+
+### Connection
+
+The `PingPongListener::Connection` type indicates a ping/pong keepalive
+mechanism on the connection.
+
+---
+
+## Image Streaming
+
+`ImageStreamEncoder::ReceiveComponentImage(juce::Image, juce::RectangleList<int>)`
+is the device-side entry point that receives rendered images from the host and
+paints them to the display. The dirty rectangle list enables partial updates.
+
+The host sends PNG-encoded images as MessageBlock payloads. The image content
+(track info, waveform, etc.) is composed on the host side before sending.
+
+---
+
+## Key Binary Symbols (planck-remote-screen)
+
+C++ class names from RTTI strings in the binary:
+
+```
+RemoteScreenApp
+RemoteScreenMainWindow
+RemoteScreenConnectedComponent
+RemoteScreenNotConnectedComponent
+RemoteScreenService
+ImageStreamEncoder
+UsbGadgetMessageBlockStream
+NetworkMessageBlockStream
+FsTransferMessageBlockStream
+MessageBlockRouter
+MessageBlockBuilderOutputStream
+SmexControlHost
+SmexControlClient
+SmexControlService
+Acvt::SmexClient
+UsbGadgetVolumeControl
+MidiOutputServiceClient
+ScreensaverTimer
+ScreensaverComponent
+```

--- a/docs/reveng/computer-mode/04-main-screen-smex.md
+++ b/docs/reveng/computer-mode/04-main-screen-smex.md
@@ -63,8 +63,19 @@ Key classes found in the binary:
 | `NetworkMessageBlockStream` | TCP transport (same wire format) |
 | `FsTransferMessageBlockStream` | Filesystem transport (firmware update images) |
 
-Wire format: not yet fully decoded. Further analysis of `planck-remote-screen`
-required.
+Wire format decoded from `serato_device_akaisdk.dll` (Serato's Akai SDK for the Prime 4):
+
+```
+[uint32 BE: total content length]
+[uint32 BE: type string length]
+[bytes: type string UTF-8]       e.g. "smex.protocolversion"
+[uint32 BE: payload length]
+[bytes: payload]
+```
+
+The `SmexControlService::Received` handler reads two length-prefixed
+strings per message: the type name then the payload. Both strings use
+`[uint32 BE length][UTF-8 bytes]` encoding.
 
 ---
 
@@ -141,3 +152,30 @@ MidiOutputServiceClient
 ScreensaverTimer
 ScreensaverComponent
 ```
+
+---
+
+## Library and Deck Display Capability
+
+The `serato_device_akaisdk.dll` (Serato's implementation of the Akai SDK)
+exposes the following display data structures in the `Akai::RemoteScreen::DjDisplay`
+namespace. These confirm that the Prime 4 screen CAN display rich content
+from the connected DJ software, not just a static "connected" screen:
+
+| Struct / Enum | Purpose |
+|---|---|
+| `DeckDisplay` | Full deck state (track info, waveform position, loop, etc.) |
+| `ListRow` | A single row in a library list view |
+| `BrowserMode` | Which browse mode is active (library, cue list, etc.) |
+| `CuePoint` | Cue point display data |
+| `WaveformLocation` | Current playhead position for waveform display |
+| `ScrollBar` | Scroll bar state for lists |
+| `DeckPressEvent` | Touch/jog press event from the device |
+| `Question` | Dialog/confirmation popup |
+| `DeckDrawingStyle` | Visual style for the deck display |
+
+The SDK is accessed via a single export `CreateAkaiSDK()` which returns an
+opaque object. All API calls are via virtual methods on the returned object.
+
+The `AkaiSDKDevices::DeviceConnected` callback fires when a Prime 4 is
+detected, providing a `Device` object through which display updates are sent.

--- a/docs/reveng/computer-mode/04-main-screen-smex.md
+++ b/docs/reveng/computer-mode/04-main-screen-smex.md
@@ -104,12 +104,15 @@ mechanism on the connection.
 
 ## Image Streaming
 
-`ImageStreamEncoder::ReceiveComponentImage(juce::Image, juce::RectangleList<int>)`
-is the device-side entry point that receives rendered images from the host and
-paints them to the display. The dirty rectangle list enables partial updates.
+The `ImageStreamEncoder::ReceiveComponentImage(juce::Image, juce::RectangleList<int>)`
+method on the device side receives rendered component images and displays them on the
+device's own 800x1280 MIPI-DSI screen via the local DRM/KMS framebuffer (`/dev/fb0`,
+`/dev/dri/...`). This is **not** a USB transfer - the display is rendered locally.
 
-The host sends PNG-encoded images as MessageBlock payloads. The image content
-(track info, waveform, etc.) is composed on the host side before sending.
+Jog wheel images are sent separately over the MIDI SysEx interface (see `03-jog-wheel-sysex.md`).
+
+The `UsbGadgetMessageBlockStream` (FunctionFS bulk stream) carries only **small SMEX
+control messages** - not pixel or image data.
 
 ---
 

--- a/docs/reveng/computer-mode/04-main-screen-smex.md
+++ b/docs/reveng/computer-mode/04-main-screen-smex.md
@@ -215,25 +215,52 @@ The following was confirmed by SSHing into the Prime 4 at runtime:
 - A soft-disconnect/reconnect cycle (`echo disconnect/connect > soft_connect`) followed
   by one clean SET_CONFIGURATION from the host resolves the blockage
 
-### Minimal working connection sequence (pseudocode)
+### Startup sequence (confirmed via strace)
+
+When the host sends SET_CONFIGURATION:
+1. planck reads 12-byte FUNCTIONFS_ENABLE event from ep0
+2. Submits 32 AIO PREADs on ep2 (4096B each) and 32 on ep4 (64B each)
+3. Previous reads complete with `res=-108` (ESHUTDOWN)
+4. Resubmits fresh 64 reads; new messages now complete with `res=64`
+5. Prints "Gadget state changed: connected"
+
+AIO callback object structure per read:
+```
+[4B magic "PGD\0"][4B vtable (JUCE lib)][4B self-ptr]...
+[4B ID][4B buf_ptr][4B buf_size=64]
+```
+
+### State machine blocker
+
+SMEX commands ARE received (confirmed by strace `io_getevents res=64` with correct
+data in buffer). However NO SMEX handler produces any visible effect.
+
+`Acvt::SmexClient` requires three conditions before dispatching handlers:
+1. `ConnectableMessageBlockStream::State = CONNECTED` (set by ENABLE event)
+2. `PingPongListener::Connection = CONNECTED` (**BLOCKER**)
+3. A `bool` enable flag
+
+planck **never** submits `IOCB_CMD_PWRITE` to ep3 under any circumstances (exhaustively
+verified by strace across all 3 threads). The PingPong pong cannot be sent over USB,
+so `SmexClient.connected` never becomes `true`, gating all SMEX handlers.
+
+Tried without success: smex.protocolversion versions 1-4, PingPong ping/pong with
+various seq IDs, EP2 bulk sends, 3+ second delays between messages.
+
+### Known working connection sequence (pseudocode - INCOMPLETE)
 
 ```python
 dev = libusb.open(vid=0x15e4, pid=0xa008)
-dev.set_configuration(1)          # triggers ffs_func_set_alt once
+dev.set_configuration(1)          # triggers ENABLE event on ep0
 dev.claim_interface(0)
 
-# Send SMEX version handshake on interrupt OUT (must be exactly 64 bytes)
-smex_version = build_smex("smex.protocolversion", "1")
-padded = smex_version + bytes(64 - len(smex_version))  # pad to 64B
-dev.write(EP4_OUT=0x04, padded)   # no response expected
+# TODO: unknown step to satisfy PingPongListener.connected
+# Without this, all SMEX handlers remain gated by SmexClient state machine
 
-# Send display commands - all via EP4 (control) and EP2 (bulk data)
-smex_brightness = build_smex("smex.brightness.set", "80")
-dev.write(EP4_OUT=0x04, smex_brightness + bytes(64 - len(smex_brightness)))
-
-# Send bulk image/content data via EP2
-dev.write(EP2_OUT=0x02, image_data)  # variable length, up to 4096B per transfer
+# These ARE received by planck but currently have no effect:
+dev.write(0x04, pad64(build_smex("smex.protocolversion", "1")))
+dev.write(0x04, pad64(build_smex("smex.brightness.set", "80")))
 ```
 
-Note: EP3 IN (0x83) and EP1 IN (0x81) exist in the USB descriptor but are not
-used by planck-remote-screen. Do not expect responses on these endpoints.
+Note: EP3 IN (0x83) and EP1 IN (0x81) exist in the USB descriptor but planck
+never writes to them. Do not expect responses.

--- a/docs/reveng/computer-mode/05-statemap-keys.md
+++ b/docs/reveng/computer-mode/05-statemap-keys.md
@@ -1,0 +1,116 @@
+# StateMap Property Paths
+
+These are Denon's internal `StateMap` key paths (slash-delimited strings)
+observed in the firmware QML files for Computer Mode display assignments.
+
+The host reads these from its own internal state and uses them to drive
+the display rendering pipeline.
+
+## Deck-specific paths
+
+Replace `%d` with the deck number (1–4) or `%s` with Left/Right.
+
+### Track metadata
+
+```
+/Engine/Deck%d/Track/SongLoaded           bool   - track is loaded
+/Engine/Deck%d/Track/TrackName            string - track title
+/Engine/Deck%d/Track/ArtistName           string - artist name
+/Engine/Deck%d/Track/AlbumName            string - album name
+/Engine/Deck%d/AlbumArt                   bytes  - album artwork (JPEG/PNG blob)
+/Engine/Deck%d/Track/SampleRate           double - sample rate (Hz)
+/Engine/Deck%d/Track/TrackData/TrackLength       double - duration (seconds)
+/Engine/Deck%d/Track/TrackData/PlayheadPosition  double - current position (seconds)
+```
+
+### Playback state
+
+```
+/Engine/Deck%d/Play                       bool   - playing
+/Engine/Deck%d/PlayState                  double - 0=stopped, 1=playing, 2=paused
+/Engine/Deck%d/PlayStatePath              string
+/Engine/Deck%d/CurrentBPM                 double - current BPM
+/Engine/Deck%d/Speed                      double - pitch-adjusted speed
+/Engine/Deck%d/SpeedNeutral               double
+/Engine/Deck%d/SpeedOffsetDown            double
+/Engine/Deck%d/SpeedOffsetUp              double
+/Engine/Deck%d/SpeedRange                 double
+/Engine/Deck%d/SpeedState                 double
+/Engine/Deck%d/SyncMode                   double
+/Engine/Deck%d/DeckIsMaster               bool
+/Engine/Deck%d/Track/KeyLock              bool
+```
+
+### Loop state
+
+```
+/Engine/Deck%d/Track/AutoLoopIndex        int    - current loop size index
+/Engine/Deck%d/Track/AutoLoopLabel%d      string - loop size label (e.g. "1/4")
+/Engine/Deck%d/Track/LoopEnableState      bool   - loop active
+/Engine/Deck%d/Track/Loop/Active          bool
+/Engine/Deck%d/Track/Loop/LoopEnabledPosition  double
+/Engine/Deck%d/Track/Loop/LoopOutPosition      double
+/Engine/Deck%d/Track/Loop/QuickLoop1..8        double
+```
+
+### Beat jump
+
+```
+/Engine/Deck%d/Track/BeatJump/BeatJumpIndex    int    - current beat jump size index
+/Engine/Deck%d/Track/BeatJump/BeatJumpLabel%d  string - size label
+```
+
+### Slip mode
+
+```
+/Engine/Deck%d/Track/SlipModeActive       bool
+```
+
+### Visual / jog
+
+```
+/Engine/Deck%d/JogColor                   color  - deck accent color
+/Engine/Deck%d/ExternalMixerVolume        double
+/Engine/Deck%d/ExternalScratchWheelTouch  bool
+/Engine/Deck%d/DeckIsMaster               bool
+```
+
+### Realtime position (high frequency)
+
+```
+/Private/Deck%d/MidiSamplePosition        int    - sample index (updated ~83 Hz)
+```
+
+## Mixer paths
+
+```
+/Engine/Mixer/Channel%d/PFL               bool   - pre-fader listen
+/Engine/Mixer/Channel%d/Line              bool   - line-in mode active
+/Engine/Mixer/Channel%d/AutoGain          double
+/Engine/Mixer/AutoPFLDeckIndex            int
+/Engine/Mixer/Deck%d/...                  (various)
+```
+
+## Client / UI paths
+
+```
+/Client/Preferences/CueSolo               bool
+/Client/Preferences/ScreenBrightnessPluggedIn  string - "Low"/"Mid"/"High"/"Max"
+/Client/Librarian/DevicesController/CurrentDeviceArtwork  bytes
+/Client/Assignments/Display/DeviceInfo    string - firmware version (for capability checks)
+/GUI/Decks/Deck%s/ActiveDeck              string - active deck number for layer
+/GUI/Scripted/RunningDark                 bool   - dark/sleep mode
+/Configuration/ComputerMode               bool   - computer mode active (set by host)
+```
+
+## Notes
+
+- These paths are used by the host to track state
+  internally and drive the display rendering QML
+- In Computer Mode the host **emits** many of these values back to the device
+  if the device requests them (via SMEX or StateMap subscription)
+- The `/Private/...` paths are high-frequency realtime values not suitable for
+  network transmission - they are computed locally and sent as MIDI pitch messages
+  instead of StateMap updates
+- `/Configuration/ComputerMode` is a key StateMap flag - setting it `true`
+  activates the computer mode UI on the device

--- a/docs/reveng/computer-mode/07-functionfs-kernel-issue.md
+++ b/docs/reveng/computer-mode/07-functionfs-kernel-issue.md
@@ -1,0 +1,140 @@
+# FunctionFS Kernel Issue - Prime 4 Computer Mode USB Communication
+
+## Problem
+
+The Prime 4 running firmware 4.3.4 (kernel `6.1.111-inmusic-2024-09-19-rt41`) has a critical bug in the dwc2 USB OTG controller driver or FunctionFS layer that prevents proper USB endpoint I/O completion signaling.
+
+## Symptoms
+
+When `planck-remote-screen` is running in Computer Mode on the Prime 4:
+
+1. Host writes to EP4 OUT (interrupt, 64B) or EP2 OUT (bulk, 512B) succeed from libusb perspective
+2. Data lands in the dwc2 DMA buffer (confirmed by reading `/dev/mem` at the DOEPDMA address)
+3. USB interrupts fire (IRQ counter increments by 1 per write)
+4. But the FunctionFS layer never signals completion to userspace:
+   - `total_data=0` in `cat /sys/kernel/debug/usb/ff580000.usb/ep[24]out`
+   - Any process attempting to read or write FunctionFS endpoint fds blocks forever
+   - AIO submit requests (PREAD via io_submit) hang in `ffs_epfile_io` at `wait_event_interruptible`
+
+## Root Cause
+
+The dwc2 USB controller receives OUT transfers correctly into DMA buffers and triggers hardware interrupts, but the dwc2 driver is not properly invoking the completion callback for FunctionFS. The FunctionFS layer thus has no way to know that data arrived, so:
+
+- Userspace applications waiting via poll/epoll on endpoint fds never get woken up
+- Userspace applications using AIO hang waiting for the completion event
+- Direct read/write calls on the endpoint fds block indefinitely
+
+This manifests as a complete communications deadlock: the device receives data but the application cannot retrieve it.
+
+## Hardware/Software Stack
+
+- **SoC**: Rockchip RK3288 (ARM Cortex-A17)
+- **USB OTG Controller**: DWC2 (Synopsys DesignWare Cores 2)
+- **Gadget Framework**: Linux FunctionFS
+- **Kernel**: `6.1.111-inmusic-2024-09-19-rt41` (custom build, PREEMPT_RT enabled)
+- **Device-side app**: `/usr/bin/planck-remote-screen` (11 MB JUCE app)
+
+## Verification
+
+### Data arrives in DMA buffer but not retrieved
+
+```bash
+# On Prime 4, write test message from host
+# Then check the DMA buffer directly:
+DOEPDMA=0x038afdc0  # from cat /sys/kernel/debug/usb/ff580000.usb/ep4out
+hexdump -C /dev/mem -s $DOEPDMA -n 64
+# Output: confirms message bytes are present in physical memory
+```
+
+### IRQ increments without completion callback
+
+```bash
+# Watch IRQ count before and after host write
+grep "ff580000" /proc/interrupts     # Before: count=191
+# [host writes to EP4 OUT]
+grep "ff580000" /proc/interrupts     # After: count=192 (+1)
+
+# But check the request status:
+cat /sys/kernel/debug/usb/ff580000.usb/ep4out
+# total_data=0  <-- kernel thinks no completion happened
+```
+
+### Read/Write operations hang
+
+```bash
+# Any of these block forever:
+cat /dev/ffs-smexstream/ep4       # blocks indefinitely
+read(fd_ep4, buf, 64)             # blocks indefinitely  
+write(fd_ep3, buf, 64)            # blocks indefinitely
+io_submit(ctx, 1, &read_iocb)    # blocks indefinitely
+```
+
+## Workarounds Considered
+
+### 1. Use Network Mode Instead of USB FunctionFS
+
+**Status**: Unknown feasibility
+
+`planck-remote-screen` binary contains two transport implementations:
+- `UsbGadgetMessageBlockStream` (FunctionFS - broken)
+- `NetworkMessageBlockStream` (TCP - may work)
+
+If the app can be configured or patched to use TCP port X instead of FunctionFS, the SMEX protocol could work over Ethernet.
+
+**Action needed**: Reverse engineer whether planck-remote-screen can be configured to listen on a TCP port, or patch the binary to enable this.
+
+### 2. Kernel Patch / Update
+
+**Status**: Requires local kernel dev environment
+
+The dwc2 and FunctionFS drivers need review to identify why:
+- dwc2 is not calling completion callbacks for OUT transfers, OR
+- FunctionFS is not propagating the callbacks to poll/epoll/AIO
+
+**Action needed**: 
+- Check dwc2 git history for fixes between 6.1.111 and latest
+- Review RK3288 dwc2 configuration for known issues
+- Test on stock 6.1.111 or upgraded kernel (6.8+)
+
+### 3. Use a Different USB Profile
+
+**Status**: Infeasible for screen display
+
+Currently Prime 4 in Computer Mode uses a vendor-specific FunctionFS gadget (`0x15e4:0xa008`, smexstream). Could instead use:
+- CDC ACM (serial port emulation) - but slower and less suitable for display data
+- Mass storage - not applicable
+- Custom USB driver - requires kernel recompilation
+
+### 4. Local IPC Instead of Remote USB
+
+**Status**: Architecture change required
+
+For Mixxx integration running on the Prime 4 itself (not over USB), bypass planck-remote-screen entirely and write directly to the framebuffer or render surface. But this breaks the intended remote-display architecture.
+
+## Current Status
+
+**Communication is blocked**: No DJ software (Serato, Engine DJ, Mixxx, etc.) can successfully control the Prime 4 screen from a remote computer in Computer Mode due to this kernel bug.
+
+The "waiting for connection" UI displayed by planck-remote-screen is a built-in fallback animation, not the result of receiving any command.
+
+## Next Steps (Priority Order)
+
+1. **Network Mode Testing**: Inspect planck-remote-screen binary for TCP network support and test if it works
+2. **Kernel Upgrade**: Test on a newer kernel (6.8 or later) to see if dwc2/FunctionFS fixes apply
+3. **Targeted Patch**: If a fix is identified, create a minimal kernel patch for 6.1.111
+4. **Binary Patching**: If kernel changes are infeasible, attempt to reverse engineer and patch planck-remote-screen to disable FunctionFS and use TCP instead
+5. **Contact Denon**: Report this as a critical bug in the Computer Mode feature
+
+## References
+
+- dwc2 driver source: `drivers/usb/dwc2/` in Linux kernel
+- FunctionFS implementation: `drivers/usb/gadget/function/f_fs.c`
+- Prime 4 rootfs: `/usr/bin/planck-remote-screen` (JUCE app with RTTI strings)
+- RK3288 OTG controller: `ff580000.usb` (address shown in dmesg)
+
+## Test Environment
+
+- Prime 4 firmware: JP11 (v4.3.4 custom)
+- Host machine: linux laptop (icedream, 192.168.187.22)
+- Server machine: icedream-homepc (192.168.187.21, Prime 4 physical connection)
+- Prime 4 IP: 192.168.187.23

--- a/docs/reveng/computer-mode/08-initialization-hypothesis.md
+++ b/docs/reveng/computer-mode/08-initialization-hypothesis.md
@@ -1,0 +1,71 @@
+# Initialization Handshake Hypothesis - MIDI SysEx Trigger
+
+## Theory
+
+The FunctionFS USB endpoints on the Prime 4 in Computer Mode may require an **initialization message via MIDI** before the device-side application (`planck-remote-screen`) activates and processes USB MessageBlock/SMEX protocol messages.
+
+## Evidence
+
+### 1. planck-remote-screen Has MIDI Input Handling
+- Binary strings: `MIDIINPUT`, `N4juce::MidiInputCallback`, `N4juce::MidiMessageCollector`
+- JUCE framework is compiled in with full MIDI input support
+- The application actively listens for MIDI messages (not passive)
+
+### 2. Engine DJ Sends Denon SysEx Commands on Startup
+- Found QML code in Engine DJ.exe that sends: `F0 00 02 0B 00 0C 05 00 01 0%1 F7`
+- This is a **Denon manufacturer SysEx** (manufacturer ID `00 02 0B`)
+- Sent during initialization for bank reset on jog wheels (command byte `0x0C`)
+- Suggests Engine DJ sends SysEx commands to initialize the Prime 4 state during startup
+
+### 3. Serato SDK Also Uses MessageBlock + MIDI
+- The `serato_device_akaisdk.dll` contains all 14 SMEX message type strings
+- Bidirectional communication expected (device initiates certain messages too)
+- Standard practice: Host sends MIDI command → Device resets/unblocks FunctionFS → Then MessageBlock communication begins
+
+### 4. Current Blockage Pattern
+- FunctionFS endpoints accept data writes into DMA buffers
+- But completion callbacks never fire (`ffs_epfile_io` blocks indefinitely)
+- This suggests the endpoints need to be "armed" or "unlocked" by receiving some kind of command
+- MIDI SysEx is the only other USB interface available (besides FunctionFS itself)
+
+## Hypothesis
+
+**When `planck-remote-screen` starts, it requires an initialization SysEx message from the host (via MIDI) to:**
+1. Establish connection state
+2. Enable or unlock the FunctionFS endpoints
+3. Start listening for SMEX MessageBlock protocol messages
+
+The initialization sequence on first connection would be:
+
+```
+HOST                              PRIME 4
+  |                                  |
+  |-- [MIDI SysEx Init cmd] -------->|  planck-remote-screen wakes up
+  |                                  |  FunctionFS endpoints become active
+  |<-- [SMEX protocolversion] -------|  Device sends version via EP3 IN
+  |
+  |-- [SMEX protocolversion] ------->|  Host confirms version via EP4 OUT
+  |
+  |<-- [SMEX version] ----------------|  Device sends firmware version
+  |
+  | ... rest of SMEX protocol ...     |
+```
+
+## Testable Predictions
+
+1. Sending ANY Denon SysEx command to the Prime 4 before attempting SMEX MessageBlock communication might unblock the endpoints
+2. The command might be a simple "online" or "acknowledge" type message (e.g., device ID inquiry response)
+3. Once the MIDI SysEx is received and processed, subsequent USB transfers to EP4 OUT and EP3 IN should complete
+
+## Next Steps
+
+1. **Identify the exact initialization SysEx command** from the captured MIDI traffic of Engine DJ connecting to Prime 4
+2. **Test hypothesis** by sending the SysEx command and then attempting SMEX handshake
+3. **Analyze the MIDI message handler** in planck-remote-screen via Ghidra to find what command unlocks FunctionFS
+4. **Monitor planck-remote-screen logs** (if available) when Engine DJ connects to see if MIDI messages are logged
+
+## Related Files
+
+- Jog wheel SysEx documentation: `/docs/reveng/computer-mode/03-jog-wheel-sysex.md`
+- SMEX protocol: `/docs/reveng/computer-mode/04-main-screen-smex.md`
+- FunctionFS kernel issue (alternative theory): `/docs/reveng/computer-mode/07-functionfs-kernel-issue.md`

--- a/docs/reveng/computer-mode/09-breakthrough-ping-response.md
+++ b/docs/reveng/computer-mode/09-breakthrough-ping-response.md
@@ -1,0 +1,59 @@
+# BREAKTHROUGH: FunctionFS Endpoints ARE Functional - Ping Received!
+
+## Discovery
+
+After sending MIDI SysEx identity request to EP4 OUT, the device responded with a "ping" message on EP3 IN.
+
+### The Response
+
+**Received on EP3 IN (interrupt):** `0000000d0070696e67`
+
+**Parsed:**
+- Outer length (BE uint32): `0x0000000d` = 13 bytes
+- Service byte: `0x00` (SmexControlService)  
+- Payload: `70696e67` = ASCII "ping"
+
+Wait, service byte is `0x00` (SmexControlService), not `0x01` (PingPongService). The "ping" is actually a string payload in a SMEX control message, not the ping/pong keepalive protocol.
+
+### Interpretation
+
+The device is likely saying "I'm ready" or "ping" as a status message within the SMEX control protocol.
+
+## Critical Finding
+
+**The endpoints ARE working!** Data successfully:
+1. Traveled from host (Computer A) through USB
+2. Was received by the dwc2 controller on the Prime 4
+3. Was processed by planck-remote-screen
+4. Generated a response message
+5. Was transmitted back to the host via USB
+
+This proves:
+- FunctionFS is not fundamentally broken
+- The endpoints complete transfers correctly in both directions
+- The device application processes messages and responds
+- The "deadlock" is NOT kernel-level
+
+## What Changed
+
+The key difference from earlier tests was that we:
+1. Did NOT call `set_configuration()` (device was already configured)
+2. Just claimed the interface
+3. Started continuous readers on both IN endpoints
+4. Sent data to EP4 OUT (interrupt endpoint, not bulk)
+
+## Next Steps
+
+1. **Respond to the ping with pong** (as the user correctly suggested)
+2. **Establish full protocol handshake** (version exchange, etc.)
+3. **Identify what made the write timeout** in subsequent attempts
+4. **Determine if response proves the MIDI SysEx initialization hypothesis** - does every fresh connection require this?
+
+## Revised Hypothesis
+
+The earlier kernel bug theory was incorrect. The real issue was:
+- We were calling `set_configuration()` multiple times (causing endpoint resets)
+- We were mixing bulk and interrupt endpoints incorrectly
+- Endpoint completion IS working; we just needed the right initialization sequence
+
+The MIDI SysEx initialization hypothesis still holds - the "ping" response came immediately after sending the MIDI identity request, suggesting there's a specific init sequence required.

--- a/docs/reveng/computer-mode/README.md
+++ b/docs/reveng/computer-mode/README.md
@@ -26,6 +26,8 @@ reverse-engineered from:
 | Jog wheel SysEx commands | complete (from QML source) |
 | Jog wheel image format | complete (198x198 PNG, SysEx-chunked) |
 | Platter position MIDI | complete |
-| Main screen USB transport | identified (FunctionFS, EP2 OUT bulk) |
-| SMEX control message names | complete (from planck-remote-screen strings) |
-| MessageBlock wire format | incomplete - needs further analysis of planck-remote-screen |
+| Main screen USB transport | complete (EP4 OUT interrupt / EP3 IN interrupt for SMEX) |
+| SMEX control message names | complete (13 types, from binary strings) |
+| MessageBlock wire format | complete (decoded from serato_device_akaisdk.dll) |
+| Service ID routing byte | complete (0x00-0x04 per service) |
+| Live communication | not yet verified end-to-end (dwc2/ffs timing issue under investigation) |

--- a/docs/reveng/computer-mode/README.md
+++ b/docs/reveng/computer-mode/README.md
@@ -1,0 +1,31 @@
+# Computer Mode - Overview
+
+This directory documents the Denon Prime 4's **USB Computer Mode** protocol,
+reverse-engineered from:
+
+- `planck-remote-screen` binary in the JP11 firmware rootfs (ARM32 ELF)
+- QML assignment files in the JP11 rootfs (`/usr/Engine/AssignmentFiles/`)
+- Live USB enumeration with `lsusb` while the device is connected via USB/IP
+
+## Documents
+
+| File | Contents |
+|---|---|
+| [01-usb-devices.md](01-usb-devices.md) | USB device layout - all 5 USB devices the Prime 4 exposes |
+| [02-startup-sequence.md](02-startup-sequence.md) | How computer mode is entered; engine.sh / remote-screen.sh flow |
+| [03-jog-wheel-sysex.md](03-jog-wheel-sysex.md) | Jog wheel OLED display protocol (SysEx over MIDI) |
+| [04-main-screen-smex.md](04-main-screen-smex.md) | Main 7" screen protocol (SMEX/MessageBlock over FunctionFS bulk) |
+| [05-statemap-keys.md](05-statemap-keys.md) | StateMap property paths used by display assignments |
+
+## Status
+
+| Protocol | Status |
+|---|---|
+| USB device enumeration | complete |
+| Computer Mode entry sequence | complete |
+| Jog wheel SysEx commands | complete (from QML source) |
+| Jog wheel image format | complete (198x198 PNG, SysEx-chunked) |
+| Platter position MIDI | complete |
+| Main screen USB transport | identified (FunctionFS, EP2 OUT bulk) |
+| SMEX control message names | complete (from planck-remote-screen strings) |
+| MessageBlock wire format | incomplete - needs further analysis of planck-remote-screen |

--- a/docs/reveng/computer-mode/smex-probe.py
+++ b/docs/reveng/computer-mode/smex-probe.py
@@ -2,150 +2,159 @@
 """
 PRIME 4 Computer Mode - SMEX protocol probe script.
 
-Run this after the device is switched to Computer Mode
-(hold VIEW -> Sources -> laptop+USB icon -> Yes).
+Confirmed wire format (from serato_device_akaisdk.dll reverse engineering):
 
-MessageBlock wire format (confirmed from serato_device_akaisdk.dll):
-  [uint32 BE: total content length]
-  [uint32 BE: type string length]
-  [bytes: type string UTF-8]
-  [uint32 BE: payload length]
-  [bytes: payload]
+  MessageBlock:
+    [uint32 BE: total length]
+    [uint8:     service ID]    0x00=SMEX 0x01=PingPong 0x02=Image 0x03=Touch 0x04=MsgBlock
+    [service payload...]
+
+  SmexControlService payload (service 0x00):
+    [uint32 BE: type name length]
+    [bytes:     type name UTF-8]
+    [uint32 BE: payload length]
+    [bytes:     payload UTF-8]
+
+  PingPongService payload (service 0x01):
+    [uint32 BE: sequence ID]
+    [uint8:     type]          0x01=ping, 0x03=pong
+
+Endpoint map:
+  EP4 OUT (0x04, interrupt, 64B max) - host to device SMEX control
+  EP3 IN  (0x83, interrupt, 64B max) - device to host SMEX responses
+  EP2 OUT (0x02, bulk, 512B)         - host to device bulk data
+  EP1 IN  (0x81, bulk, 512B)         - device to host bulk data
+
+Connection sequence:
+  1. set_configuration(1)  - triggers ffs_func_set_alt ONCE
+  2. claim_interface(0)
+  3. Start reading EP3 IN and EP1 IN continuously
+  4. Write smex.protocolversion to EP4 OUT
 """
-import usb.core, usb.util, struct, time, os, sys
+import usb.core, usb.util, struct, time, threading, sys
 
 VENDOR  = 0x15e4
-PRODUCT = 0xa008  # PRIME 4 Screen
-EP_OUT  = 0x02    # EP2 OUT bulk - host -> device
-EP_IN   = 0x81    # EP1 IN bulk  - device -> host
-EP_INT_OUT = 0x04
-EP_INT_IN  = 0x83
+PRODUCT = 0xa008
+
+EP_SMEX_OUT  = 0x04   # interrupt OUT - SMEX control messages
+EP_SMEX_IN   = 0x83   # interrupt IN  - SMEX responses
+EP_BULK_OUT  = 0x02   # bulk OUT - large data
+EP_BULK_IN   = 0x81   # bulk IN  - large data
 
 
-def open_device():
+def build_smex(type_str, payload=""):
+    """Build a SMEX MessageBlock for EP4 OUT (interrupt, max 64B)."""
+    tb = type_str.encode('utf-8')
+    pb = payload.encode('utf-8') if isinstance(payload, str) else payload
+    inner = bytes([0x00])  # service ID = SmexControlService
+    inner += struct.pack('>I', len(tb)) + tb
+    inner += struct.pack('>I', len(pb)) + pb
+    return struct.pack('>I', len(inner)) + inner
+
+
+def build_ping(seq=1):
+    """Build a PingPong ping message for EP4 OUT."""
+    inner = bytes([0x01])  # service ID = PingPongService
+    inner += struct.pack('>I', seq) + bytes([0x01])  # seq + ping type
+    return struct.pack('>I', len(inner)) + inner
+
+
+def parse_response(data):
+    """Parse an incoming MessageBlock from EP3 IN."""
+    if len(data) < 5:
+        return None
+    total_len = struct.unpack_from('>I', data, 0)[0]
+    if len(data) < 4 + total_len:
+        return None
+    service_id = data[4]
+    payload = data[5:4 + total_len]
+
+    if service_id == 0x00:  # SmexControlService
+        if len(payload) < 4:
+            return {'service': 'smex', 'type': '?', 'value': '?'}
+        tlen = struct.unpack_from('>I', payload, 0)[0]
+        type_str = payload[4:4+tlen].decode('utf-8', errors='replace')
+        vlen = struct.unpack_from('>I', payload, 4+tlen)[0] if len(payload) >= 8+tlen else 0
+        value = payload[8+tlen:8+tlen+vlen].decode('utf-8', errors='replace')
+        return {'service': 'smex', 'type': type_str, 'value': value}
+    elif service_id == 0x01:  # PingPongService
+        if len(payload) >= 5:
+            seq = struct.unpack_from('>I', payload, 0)[0]
+            typ = payload[4]
+            return {'service': 'ping', 'seq': seq, 'type': typ}
+    return {'service': f'svc_{service_id:02x}', 'raw': data.hex()}
+
+
+def main():
     dev = usb.core.find(idVendor=VENDOR, idProduct=PRODUCT)
     if dev is None:
         print("PRIME 4 Screen not found. Is the device in Computer Mode?")
         sys.exit(1)
-    if dev.is_kernel_driver_active(0):
-        dev.detach_kernel_driver(0)
-    usb.util.claim_interface(dev, 0)
-    print(f"Opened PRIME 4 Screen (bus {dev.bus}, dev {dev.address})")
-    return dev
 
+    print(f"Found PRIME 4 Screen: bus={dev.bus} dev={dev.address}")
 
-def read_all(dev, timeout=1000):
-    results = []
-    for ep, sz, name in [(EP_IN, 512, "bulk"), (EP_INT_IN, 64, "intr")]:
-        try:
-            d = dev.read(ep, sz, timeout=timeout)
-            results.append((name, bytes(d)))
-        except usb.core.USBTimeoutError:
-            pass
-        except Exception as e:
-            results.append((name, f"ERR:{e}"))
-    return results
-
-
-def parse_response(raw):
-    """Try to parse an incoming MessageBlock."""
-    if len(raw) < 4:
-        return None
-    total_len = struct.unpack_from('>I', raw, 0)[0]
-    if len(raw) < 4 + total_len:
-        return None
-    pos = 4
-    strings = []
-    while pos < 4 + total_len:
-        if pos + 4 > len(raw):
-            break
-        slen = struct.unpack_from('>I', raw, pos)[0]
-        pos += 4
-        if pos + slen > len(raw):
-            break
-        s = raw[pos:pos+slen]
-        strings.append(s)
-        pos += slen
-    return strings
-
-
-def messageblock(type_str, payload=b""):
-    """Build a MessageBlock with the confirmed wire format."""
-    type_b    = type_str.encode('utf-8')
-    inner     = (struct.pack('>I', len(type_b)) + type_b +
-                 struct.pack('>I', len(payload)) + payload)
-    return struct.pack('>I', len(inner)) + inner
-
-
-def probe(dev, label, payload, ep=EP_OUT, timeout=2000):
+    # Step 1: SET_CONFIGURATION (once - triggers ffs_func_set_alt)
     try:
-        n = dev.write(ep, payload, timeout=1000)
-        time.sleep(0.15)
-        resp = read_all(dev, timeout)
-        if resp:
-            for ch, d in resp:
-                if isinstance(d, bytes):
-                    parsed = parse_response(d)
-                    print(f"  [{label}] RESPONSE on {ch} ({len(d)}B): {d.hex()}")
-                    if parsed:
-                        for i, s in enumerate(parsed):
-                            try:
-                                print(f"    string[{i}]: {repr(s.decode('utf-8'))}")
-                            except:
-                                print(f"    string[{i}]: {s.hex()}")
-                    return d
-        else:
-            print(f"  [{label}] no response ({n}B sent)")
-    except Exception as e:
-        print(f"  [{label}] error: {e}")
-    return None
+        if dev.is_kernel_driver_active(0):
+            dev.detach_kernel_driver(0)
+    except: pass
+    dev.set_configuration()
+    print("SET_CONFIGURATION sent")
+    time.sleep(0.5)
 
+    # Step 2: Claim interface
+    usb.util.claim_interface(dev, 0)
+    print("Interface 0 claimed")
 
-def main():
-    dev = open_device()
+    received = []
+    stop = threading.Event()
 
-    print("\n--- Listening for spontaneous data (3s) ---")
-    for ch, d in read_all(dev, 3000):
-        if isinstance(d, bytes):
-            print(f"  Spontaneous {ch}: {d.hex()}")
-            parsed = parse_response(d)
-            if parsed:
-                for i, s in enumerate(parsed):
-                    print(f"    string[{i}]: {repr(s.decode('utf-8', errors='replace'))}")
+    # Step 3: Keep IN endpoints polled continuously
+    def reader(ep, sz, name):
+        while not stop.is_set():
+            try:
+                d = dev.read(ep, sz, timeout=300)
+                parsed = parse_response(bytes(d))
+                received.append((name, bytes(d), parsed))
+                print(f"\n  *** {name} ({len(d)}B): {bytes(d).hex()}")
+                if parsed:
+                    print(f"      parsed: {parsed}")
+            except usb.core.USBTimeoutError:
+                pass
+            except Exception as e:
+                if not stop.is_set():
+                    print(f"  {name} error: {e}")
+                break
 
-    print("\n--- CONFIRMED FORMAT: [total_len][type_len][type][payload_len][payload] ---")
+    for ep, sz, name in [(EP_SMEX_IN, 64, "EP3-intr-IN"), (EP_BULK_IN, 512, "EP1-bulk-IN")]:
+        t = threading.Thread(target=reader, args=(ep, sz, name), daemon=True)
+        t.start()
 
-    # Protocol version handshake - the first message to send
-    print("\n[1] smex.protocolversion (version=1)")
-    msg = messageblock("smex.protocolversion", b"\x00\x00\x00\x01")
-    probe(dev, "protocolversion", msg)
+    time.sleep(0.3)
 
-    print("\n[2] smex.version (empty payload)")
-    probe(dev, "version", messageblock("smex.version"))
+    # Step 4: Send smex.protocolversion handshake
+    print("\n--- Sending smex.protocolversion ---")
+    msg = build_smex("smex.protocolversion", "1")
+    print(f"  EP4 OUT: {msg.hex()}")
+    dev.write(EP_SMEX_OUT, msg, timeout=2000)
 
-    print("\n[3] smex.time.request (empty)")
-    probe(dev, "time.request", messageblock("smex.time.request"))
+    # Also send on bulk in case both are needed
+    dev.write(EP_BULK_OUT, msg, timeout=2000)
 
-    print("\n[4] smex.brightness.request (empty)")
-    probe(dev, "brightness.request", messageblock("smex.brightness.request"))
+    # Send a ping
+    print("\n--- Sending ping ---")
+    ping = build_ping(1)
+    dev.write(EP_SMEX_OUT, ping, timeout=2000)
 
-    # Try sending version=1 as just the string "1"
-    print("\n[5] smex.protocolversion payload='1'")
-    probe(dev, "protocolversion-str", messageblock("smex.protocolversion", b"1"))
+    print("\nWaiting 10s for responses...")
+    time.sleep(10)
+    stop.set()
 
-    # Library browsing - the DjDisplay structs include ListRow, BrowserMode
-    print("\n[6] Testing library commands via smex")
-    for t in ["smex.unknown", "screen.library", "dj.library.request"]:
-        probe(dev, t, messageblock(t))
-
-    # Try sending on interrupt endpoint instead
-    print("\n--- Interrupt endpoint ---")
-    for t in ["smex.protocolversion", "smex.version"]:
-        msg = messageblock(t, b"\x00\x00\x00\x01")
-        probe(dev, f"intr:{t}", msg, ep=EP_INT_OUT, timeout=1000)
+    print(f"\nTotal received: {len(received)}")
+    for name, raw, parsed in received:
+        print(f"  {name}: {parsed or raw.hex()}")
 
     usb.util.release_interface(dev, 0)
-    print("\nDone. Run with device in Computer Mode for best results.")
 
 
 if __name__ == "__main__":

--- a/docs/reveng/computer-mode/smex-probe.py
+++ b/docs/reveng/computer-mode/smex-probe.py
@@ -5,8 +5,12 @@ PRIME 4 Computer Mode - SMEX protocol probe script.
 Run this after the device is switched to Computer Mode
 (hold VIEW -> Sources -> laptop+USB icon -> Yes).
 
-The script tries multiple candidate MessageBlock wire formats
-to discover the correct framing for SMEX control messages.
+MessageBlock wire format (confirmed from serato_device_akaisdk.dll):
+  [uint32 BE: total content length]
+  [uint32 BE: type string length]
+  [bytes: type string UTF-8]
+  [uint32 BE: payload length]
+  [bytes: payload]
 """
 import usb.core, usb.util, struct, time, os, sys
 
@@ -14,8 +18,9 @@ VENDOR  = 0x15e4
 PRODUCT = 0xa008  # PRIME 4 Screen
 EP_OUT  = 0x02    # EP2 OUT bulk - host -> device
 EP_IN   = 0x81    # EP1 IN bulk  - device -> host
-EP_INT_OUT = 0x04 # EP4 OUT interrupt
-EP_INT_IN  = 0x83 # EP3 IN interrupt
+EP_INT_OUT = 0x04
+EP_INT_IN  = 0x83
+
 
 def open_device():
     dev = usb.core.find(idVendor=VENDOR, idProduct=PRODUCT)
@@ -28,8 +33,8 @@ def open_device():
     print(f"Opened PRIME 4 Screen (bus {dev.bus}, dev {dev.address})")
     return dev
 
+
 def read_all(dev, timeout=1000):
-    """Try to read from both IN endpoints."""
     results = []
     for ep, sz, name in [(EP_IN, 512, "bulk"), (EP_INT_IN, 64, "intr")]:
         try:
@@ -41,15 +46,53 @@ def read_all(dev, timeout=1000):
             results.append((name, f"ERR:{e}"))
     return results
 
-def probe(dev, label, payload, timeout=2000):
+
+def parse_response(raw):
+    """Try to parse an incoming MessageBlock."""
+    if len(raw) < 4:
+        return None
+    total_len = struct.unpack_from('>I', raw, 0)[0]
+    if len(raw) < 4 + total_len:
+        return None
+    pos = 4
+    strings = []
+    while pos < 4 + total_len:
+        if pos + 4 > len(raw):
+            break
+        slen = struct.unpack_from('>I', raw, pos)[0]
+        pos += 4
+        if pos + slen > len(raw):
+            break
+        s = raw[pos:pos+slen]
+        strings.append(s)
+        pos += slen
+    return strings
+
+
+def messageblock(type_str, payload=b""):
+    """Build a MessageBlock with the confirmed wire format."""
+    type_b    = type_str.encode('utf-8')
+    inner     = (struct.pack('>I', len(type_b)) + type_b +
+                 struct.pack('>I', len(payload)) + payload)
+    return struct.pack('>I', len(inner)) + inner
+
+
+def probe(dev, label, payload, ep=EP_OUT, timeout=2000):
     try:
-        n = dev.write(EP_OUT, payload, timeout=1000)
-        time.sleep(0.1)
+        n = dev.write(ep, payload, timeout=1000)
+        time.sleep(0.15)
         resp = read_all(dev, timeout)
         if resp:
             for ch, d in resp:
                 if isinstance(d, bytes):
-                    print(f"  [{label}] RESPONSE on {ch}: {d.hex()}")
+                    parsed = parse_response(d)
+                    print(f"  [{label}] RESPONSE on {ch} ({len(d)}B): {d.hex()}")
+                    if parsed:
+                        for i, s in enumerate(parsed):
+                            try:
+                                print(f"    string[{i}]: {repr(s.decode('utf-8'))}")
+                            except:
+                                print(f"    string[{i}]: {s.hex()}")
                     return d
         else:
             print(f"  [{label}] no response ({n}B sent)")
@@ -57,87 +100,53 @@ def probe(dev, label, payload, timeout=2000):
         print(f"  [{label}] error: {e}")
     return None
 
-def smex_msg_utf8(type_str, payload_bytes=b""):
-    """
-    Candidate format 1: [4B BE total-len][4B BE type-str-len][type-str UTF-8][4B BE payload-len][payload]
-    """
-    type_b = type_str.encode('utf-8')
-    inner = struct.pack('>I', len(type_b)) + type_b + struct.pack('>I', len(payload_bytes)) + payload_bytes
-    return struct.pack('>I', len(inner)) + inner
-
-def smex_msg_cstr(type_str, payload_bytes=b""):
-    """
-    Candidate format 2: [4B BE total-len][null-terminated type-str][4B BE payload-len][payload]
-    """
-    type_b = type_str.encode('utf-8') + b'\x00'
-    inner = type_b + struct.pack('>I', len(payload_bytes)) + payload_bytes
-    return struct.pack('>I', len(inner)) + inner
-
-def smex_msg_id(type_id, payload_bytes=b""):
-    """
-    Candidate format 3: [4B BE total-len][4B BE type-id][payload]
-    (numeric type IDs, no string)
-    """
-    inner = struct.pack('>I', type_id) + payload_bytes
-    return struct.pack('>I', len(inner)) + inner
-
-def stagelinq_msg(msg_id, payload):
-    """
-    Candidate format 4: StageLinQ wire format [4B BE len][payload]
-    where payload = [4B BE msgID][content...]
-    """
-    inner = struct.pack('>I', msg_id) + payload
-    return struct.pack('>I', len(inner)) + inner
 
 def main():
     dev = open_device()
 
-    print("\n--- Listening for spontaneous data (5s) ---")
-    for ch, d in read_all(dev, 5000):
+    print("\n--- Listening for spontaneous data (3s) ---")
+    for ch, d in read_all(dev, 3000):
         if isinstance(d, bytes):
             print(f"  Spontaneous {ch}: {d.hex()}")
+            parsed = parse_response(d)
+            if parsed:
+                for i, s in enumerate(parsed):
+                    print(f"    string[{i}]: {repr(s.decode('utf-8', errors='replace'))}")
 
-    token = os.urandom(16)
+    print("\n--- CONFIRMED FORMAT: [total_len][type_len][type][payload_len][payload] ---")
 
-    print("\n--- Format 1: [len][utf8-type-len][utf8-type][payload-len][payload] ---")
+    # Protocol version handshake - the first message to send
+    print("\n[1] smex.protocolversion (version=1)")
+    msg = messageblock("smex.protocolversion", b"\x00\x00\x00\x01")
+    probe(dev, "protocolversion", msg)
+
+    print("\n[2] smex.version (empty payload)")
+    probe(dev, "version", messageblock("smex.version"))
+
+    print("\n[3] smex.time.request (empty)")
+    probe(dev, "time.request", messageblock("smex.time.request"))
+
+    print("\n[4] smex.brightness.request (empty)")
+    probe(dev, "brightness.request", messageblock("smex.brightness.request"))
+
+    # Try sending version=1 as just the string "1"
+    print("\n[5] smex.protocolversion payload='1'")
+    probe(dev, "protocolversion-str", messageblock("smex.protocolversion", b"1"))
+
+    # Library browsing - the DjDisplay structs include ListRow, BrowserMode
+    print("\n[6] Testing library commands via smex")
+    for t in ["smex.unknown", "screen.library", "dj.library.request"]:
+        probe(dev, t, messageblock(t))
+
+    # Try sending on interrupt endpoint instead
+    print("\n--- Interrupt endpoint ---")
     for t in ["smex.protocolversion", "smex.version"]:
-        probe(dev, f"fmt1:{t}", smex_msg_utf8(t, b"\x00\x00\x00\x01"))
-
-    print("\n--- Format 2: [len][cstr-type][payload-len][payload] ---")
-    for t in ["smex.protocolversion", "smex.version"]:
-        probe(dev, f"fmt2:{t}", smex_msg_cstr(t, b"\x00\x00\x00\x01"))
-
-    print("\n--- Format 3: [len][type-id uint32][payload] (numeric IDs 0..5) ---")
-    for i in range(6):
-        probe(dev, f"fmt3:id={i}", smex_msg_id(i, b"\x01"))
-
-    print("\n--- Format 4: StageLinQ service announcement ---")
-    def utf16(s): b = s.encode('utf-16-be'); return struct.pack('>I',len(b))+b
-    svc = token + utf16("Mixxx") + struct.pack('>H', 51337)
-    probe(dev, "stagelinq:service-announce", stagelinq_msg(0x00000000, svc))
-
-    print("\n--- Format 4b: StageLinQ services request ---")
-    probe(dev, "stagelinq:services-request", stagelinq_msg(0x00000002, token))
-
-    print("\n--- Format 5: plain [len][payload] with 'smex' magic ---")
-    for magic in [b"smex", b"SMEX", b"\x00\x00\x00\x01"]:
-        probe(dev, f"magic:{magic.hex()}", struct.pack('>I', 8) + magic + b"\x00"*4)
-
-    print("\n--- Format 6: interrupt OUT endpoint ---")
-    for t in ["smex.protocolversion", "smex.version"]:
-        try:
-            n = dev.write(EP_INT_OUT, smex_msg_utf8(t, b""), timeout=500)
-            time.sleep(0.1)
-            resp = read_all(dev, 1000)
-            if resp:
-                print(f"  [intr:{t}] RESPONSE: {resp}")
-            else:
-                print(f"  [intr:{t}] no response ({n}B sent)")
-        except Exception as e:
-            print(f"  [intr:{t}] error: {e}")
+        msg = messageblock(t, b"\x00\x00\x00\x01")
+        probe(dev, f"intr:{t}", msg, ep=EP_INT_OUT, timeout=1000)
 
     usb.util.release_interface(dev, 0)
-    print("\nDone.")
+    print("\nDone. Run with device in Computer Mode for best results.")
+
 
 if __name__ == "__main__":
     main()

--- a/docs/reveng/computer-mode/smex-probe.py
+++ b/docs/reveng/computer-mode/smex-probe.py
@@ -2,87 +2,55 @@
 """
 PRIME 4 Computer Mode - SMEX protocol probe script.
 
-Confirmed wire format (from serato_device_akaisdk.dll reverse engineering):
+Protocol is UNIDIRECTIONAL (host to device only):
+  - EP4 OUT (0x04, interrupt, 64B) - control messages, MUST be exactly 64B
+  - EP2 OUT (0x02, bulk, up to 4096B) - bulk data (images etc.)
+  - EP3 IN  (0x83) and EP1 IN (0x81) exist in descriptor but planck NEVER writes
+    to them - do not expect any responses
 
-  MessageBlock:
-    [uint32 BE: total length]
-    [uint8:     service ID]    0x00=SMEX 0x01=PingPong 0x02=Image 0x03=Touch 0x04=MsgBlock
-    [service payload...]
+Confirmed via strace of planck-remote-screen:
+  - planck submits 32 AIO PREADs on ep2 and ep4 at startup
+  - planck never issues io_submit PWRITE or write() to ep1 or ep3
+  - 64B padding is REQUIRED for EP4 - short packets cause io_getevents to never fire
 
-  SmexControlService payload (service 0x00):
-    [uint32 BE: type name length]
-    [bytes:     type name UTF-8]
-    [uint32 BE: payload length]
-    [bytes:     payload UTF-8]
+Wire format (MessageBlock):
+  [uint32 BE: content length]
+  [uint8:     service ID]     0x00=SMEX 0x01=PingPong 0x02=Image 0x03=Touch
+  [service payload...]
 
-  PingPongService payload (service 0x01):
-    [uint32 BE: sequence ID]
-    [uint8:     type]          0x01=ping, 0x03=pong
+SmexControlService (service 0x00):
+  [uint32 BE: type name length]
+  [bytes:     type name UTF-8]   e.g. "smex.protocolversion"
+  [uint32 BE: value length]
+  [bytes:     value UTF-8]
 
-Endpoint map:
-  EP4 OUT (0x04, interrupt, 64B max) - host to device SMEX control
-  EP3 IN  (0x83, interrupt, 64B max) - device to host SMEX responses
-  EP2 OUT (0x02, bulk, 512B)         - host to device bulk data
-  EP1 IN  (0x81, bulk, 512B)         - device to host bulk data
-
-Connection sequence:
-  1. set_configuration(1)  - triggers ffs_func_set_alt ONCE
-  2. claim_interface(0)
-  3. Start reading EP3 IN and EP1 IN continuously
-  4. Write smex.protocolversion to EP4 OUT
+PingPongService (service 0x01):
+  [uint32 LE: sequence ID]
+  [uint8:     type]            0x01=ping, 0x03=pong
 """
-import usb.core, usb.util, struct, time, threading, sys
+import usb.core, usb.util, struct, time, sys
 
 VENDOR  = 0x15e4
 PRODUCT = 0xa008
 
-EP_SMEX_OUT  = 0x04   # interrupt OUT - SMEX control messages
-EP_SMEX_IN   = 0x83   # interrupt IN  - SMEX responses
+EP_CTRL_OUT  = 0x04   # interrupt OUT - SMEX control (64B, must pad)
 EP_BULK_OUT  = 0x02   # bulk OUT - large data
-EP_BULK_IN   = 0x81   # bulk IN  - large data
+
+
+def pad64(data):
+    """Pad message to exactly 64 bytes (required for EP4 interrupt endpoint)."""
+    assert len(data) <= 64, f"SMEX message too large ({len(data)}B > 64B)"
+    return data + bytes(64 - len(data))
 
 
 def build_smex(type_str, payload=""):
-    """Build a SMEX MessageBlock for EP4 OUT (interrupt, max 64B)."""
+    """Build a SMEX MessageBlock for EP4 OUT."""
     tb = type_str.encode('utf-8')
     pb = payload.encode('utf-8') if isinstance(payload, str) else payload
-    inner = bytes([0x00])  # service ID = SmexControlService
+    inner = bytes([0x00])
     inner += struct.pack('>I', len(tb)) + tb
     inner += struct.pack('>I', len(pb)) + pb
     return struct.pack('>I', len(inner)) + inner
-
-
-def build_ping(seq=1):
-    """Build a PingPong ping message for EP4 OUT."""
-    inner = bytes([0x01])  # service ID = PingPongService
-    inner += struct.pack('>I', seq) + bytes([0x01])  # seq + ping type
-    return struct.pack('>I', len(inner)) + inner
-
-
-def parse_response(data):
-    """Parse an incoming MessageBlock from EP3 IN."""
-    if len(data) < 5:
-        return None
-    total_len = struct.unpack_from('>I', data, 0)[0]
-    if len(data) < 4 + total_len:
-        return None
-    service_id = data[4]
-    payload = data[5:4 + total_len]
-
-    if service_id == 0x00:  # SmexControlService
-        if len(payload) < 4:
-            return {'service': 'smex', 'type': '?', 'value': '?'}
-        tlen = struct.unpack_from('>I', payload, 0)[0]
-        type_str = payload[4:4+tlen].decode('utf-8', errors='replace')
-        vlen = struct.unpack_from('>I', payload, 4+tlen)[0] if len(payload) >= 8+tlen else 0
-        value = payload[8+tlen:8+tlen+vlen].decode('utf-8', errors='replace')
-        return {'service': 'smex', 'type': type_str, 'value': value}
-    elif service_id == 0x01:  # PingPongService
-        if len(payload) >= 5:
-            seq = struct.unpack_from('>I', payload, 0)[0]
-            typ = payload[4]
-            return {'service': 'ping', 'seq': seq, 'type': typ}
-    return {'service': f'svc_{service_id:02x}', 'raw': data.hex()}
 
 
 def main():
@@ -93,66 +61,49 @@ def main():
 
     print(f"Found PRIME 4 Screen: bus={dev.bus} dev={dev.address}")
 
-    # Step 1: SET_CONFIGURATION (once - triggers ffs_func_set_alt)
     try:
         if dev.is_kernel_driver_active(0):
             dev.detach_kernel_driver(0)
     except: pass
-    dev.set_configuration()
-    print("SET_CONFIGURATION sent")
-    time.sleep(0.5)
 
-    # Step 2: Claim interface
+    try:
+        dev.set_configuration()
+        print("SET_CONFIGURATION sent")
+    except Exception as e:
+        print(f"SET_CONFIGURATION: {e} (may already be configured)")
+
+    time.sleep(0.2)
     usb.util.claim_interface(dev, 0)
     print("Interface 0 claimed")
 
-    received = []
-    stop = threading.Event()
-
-    # Step 3: Keep IN endpoints polled continuously
-    def reader(ep, sz, name):
-        while not stop.is_set():
-            try:
-                d = dev.read(ep, sz, timeout=300)
-                parsed = parse_response(bytes(d))
-                received.append((name, bytes(d), parsed))
-                print(f"\n  *** {name} ({len(d)}B): {bytes(d).hex()}")
-                if parsed:
-                    print(f"      parsed: {parsed}")
-            except usb.core.USBTimeoutError:
-                pass
-            except Exception as e:
-                if not stop.is_set():
-                    print(f"  {name} error: {e}")
-                break
-
-    for ep, sz, name in [(EP_SMEX_IN, 64, "EP3-intr-IN"), (EP_BULK_IN, 512, "EP1-bulk-IN")]:
-        t = threading.Thread(target=reader, args=(ep, sz, name), daemon=True)
-        t.start()
-
-    time.sleep(0.3)
-
-    # Step 4: Send smex.protocolversion handshake
+    # Send smex.protocolversion (must be padded to 64B)
     print("\n--- Sending smex.protocolversion ---")
     msg = build_smex("smex.protocolversion", "1")
-    print(f"  EP4 OUT: {msg.hex()}")
-    dev.write(EP_SMEX_OUT, msg, timeout=2000)
+    print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
+    dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
+    time.sleep(0.1)
 
-    # Also send on bulk in case both are needed
-    dev.write(EP_BULK_OUT, msg, timeout=2000)
+    # Send smex.time.request
+    print("\n--- Sending smex.time.request ---")
+    msg = build_smex("smex.time.request")
+    print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
+    dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
+    time.sleep(0.1)
 
-    # Send a ping
-    print("\n--- Sending ping ---")
-    ping = build_ping(1)
-    dev.write(EP_SMEX_OUT, ping, timeout=2000)
+    # Send smex.brightness.set with value 50
+    print("\n--- Sending smex.brightness.set = 50 ---")
+    msg = build_smex("smex.brightness.set", "50")
+    print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
+    dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
+    time.sleep(0.5)
 
-    print("\nWaiting 10s for responses...")
-    time.sleep(10)
-    stop.set()
+    # Restore brightness to 100
+    print("\n--- Restoring smex.brightness.set = 100 ---")
+    msg = build_smex("smex.brightness.set", "100")
+    dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
 
-    print(f"\nTotal received: {len(received)}")
-    for name, raw, parsed in received:
-        print(f"  {name}: {parsed or raw.hex()}")
+    print("\nNote: no responses expected (protocol is unidirectional)")
+    print("Check if screen brightness changed to confirm EP4 messages are received")
 
     usb.util.release_interface(dev, 0)
 

--- a/docs/reveng/computer-mode/smex-probe.py
+++ b/docs/reveng/computer-mode/smex-probe.py
@@ -2,11 +2,10 @@
 """
 PRIME 4 Computer Mode - SMEX protocol probe script.
 
-Protocol is UNIDIRECTIONAL (host to device only):
+Protocol appears unidirectional, but we'll listen for responses:
   - EP4 OUT (0x04, interrupt, 64B) - control messages, MUST be exactly 64B
   - EP2 OUT (0x02, bulk, up to 4096B) - bulk data (images etc.)
-  - EP3 IN  (0x83) and EP1 IN (0x81) exist in descriptor but planck NEVER writes
-    to them - do not expect any responses
+  - EP3 IN  (0x83) and EP1 IN (0x81) - read attempts (may receive responses or empty)
 
 Confirmed via strace of planck-remote-screen:
   - planck submits 32 AIO PREADs on ep2 and ep4 at startup
@@ -25,7 +24,7 @@ SmexControlService (service 0x00):
   [bytes:     value UTF-8]
 
 PingPongService (service 0x01):
-  [uint32 LE: sequence ID]
+  [uint32 BE: sequence ID]
   [uint8:     type]            0x01=ping, 0x03=pong
 """
 import usb.core, usb.util, struct, time, sys
@@ -43,6 +42,22 @@ def pad64(data):
     return data + bytes(64 - len(data))
 
 
+def build_ping():
+    """Build a SMEX PingPongService PING message."""
+    # Sequence ID: incrementing counter (use current time for demo)
+    seq_id = int(time.time() * 1000) & 0xFFFFFFFF
+    inner = struct.pack('>I', seq_id)
+    inner += bytes([0x01])  # type = ping
+    return inner
+
+
+def build_pong(seq_id):
+    """Build a SMEX PingPongService PONG message."""
+    inner = struct.pack('>I', seq_id)
+    inner += bytes([0x03])  # type = pong
+    return inner
+
+
 def build_smex(type_str, payload=""):
     """Build a SMEX MessageBlock for EP4 OUT."""
     tb = type_str.encode('utf-8')
@@ -51,6 +66,19 @@ def build_smex(type_str, payload=""):
     inner += struct.pack('>I', len(tb)) + tb
     inner += struct.pack('>I', len(pb)) + pb
     return struct.pack('>I', len(inner)) + inner
+
+
+def read_from_in_endpoint(dev, ep_addr):
+    """Read from an IN endpoint. Returns data bytes or None if timeout."""
+    try:
+        data = dev.read(ep_addr, 4096, timeout=1000)
+        return data
+    except usb.core.USBTimeoutError:
+        return None
+    except usb.core.USBError as e:
+        if e.errno == 110:  # timeout
+            return None
+        raise
 
 
 def main():
@@ -76,34 +104,82 @@ def main():
     usb.util.claim_interface(dev, 0)
     print("Interface 0 claimed")
 
+    # Set up reading from IN endpoints in a background thread
+    import threading
+    responses = []
+    stop_reading = threading.Event()
+
+    def read_in_endpoint_thread(ep_addr, name):
+        """Background thread that continuously reads from an IN endpoint."""
+        while not stop_reading.is_set():
+            data = read_from_in_endpoint(dev, ep_addr)
+            if data is not None and len(data) > 0:
+                responses.append({
+                    'ep': name,
+                    'data': data,
+                    'hex': data.hex()
+                })
+                print(f"\n[Received {name}]: {len(data)} bytes = {data.hex()}")
+            time.sleep(0.01)  # Small sleep to avoid hogging CPU
+
+    # Start background readers for EP1 IN and EP3 IN
+    reader_threads = []
+    for ep_addr, ep_name in [(0x81, 'EP1 IN'), (0x83, 'EP3 IN')]:
+        t = threading.Thread(target=read_in_endpoint_thread, args=(ep_addr, ep_name), daemon=True)
+        t.start()
+        reader_threads.append(t)
+    print("Started background readers for EP1 IN and EP3 IN")
+
+    ## Send SMEX PingPong PING to initiate keepalive
+    #print("\n--- Sending PingPong PING ---")
+    #msg = pad64(build_ping())
+    #print(f"  EP4 OUT (not padded): {msg.hex()}")
+    ## PingPongService message, send without 64B padding
+    #dev.write(EP_CTRL_OUT, msg, timeout=2000)
+    #time.sleep(0.5)
+
     # Send smex.protocolversion (must be padded to 64B)
     print("\n--- Sending smex.protocolversion ---")
     msg = build_smex("smex.protocolversion", "1")
     print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
     dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
-    time.sleep(0.1)
+    time.sleep(0.2)
 
-    # Send smex.time.request
-    print("\n--- Sending smex.time.request ---")
-    msg = build_smex("smex.time.request")
-    print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
-    dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
-    time.sleep(0.1)
+    ## Send smex.time.request
+    #print("\n--- Sending smex.time.request ---")
+    #msg = build_smex("smex.time.request")
+    #print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
+    #dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
+    #time.sleep(0.2)
 
-    # Send smex.brightness.set with value 50
-    print("\n--- Sending smex.brightness.set = 50 ---")
-    msg = build_smex("smex.brightness.set", "50")
-    print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
-    dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
-    time.sleep(0.5)
+    while True:
+        for b in ["50","100","150","200","250"]:
+            # Send smex.brightness.set with value 50
+            print(f"\n--- Sending smex.brightness.set = {b} ---")
+            msg = build_smex("smex.brightness.set", b)
+            print(f"  EP4 OUT (padded to 64B): {pad64(msg).hex()}")
+            dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
+            time.sleep(0.5)
+            dev.write(EP_CTRL_OUT, pad64(bytes([0])), timeout=2000)
+            time.sleep(0.5)
 
-    # Restore brightness to 100
-    print("\n--- Restoring smex.brightness.set = 100 ---")
-    msg = build_smex("smex.brightness.set", "100")
-    dev.write(EP_CTRL_OUT, pad64(msg), timeout=2000)
+    time.sleep(0.5)  # Wait for any responses
 
-    print("\nNote: no responses expected (protocol is unidirectional)")
-    print("Check if screen brightness changed to confirm EP4 messages are received")
+    # Stop background readers
+    stop_reading.set()
+    for t in reader_threads:
+        t.join(timeout=1.0)
+
+    # Display summary of responses
+    print("\n" + "="*50)
+    print("SUMMARY")
+    print("="*50)
+    if responses:
+        print(f"\nReceived {len(responses)} response(s):")
+        for resp in responses:
+            print(f"  {resp['ep']}: {len(resp['data'])} bytes = {resp['hex']}")
+    else:
+        print("\nNo responses received")
 
     usb.util.release_interface(dev, 0)
 

--- a/docs/reveng/computer-mode/smex-probe.py
+++ b/docs/reveng/computer-mode/smex-probe.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+PRIME 4 Computer Mode - SMEX protocol probe script.
+
+Run this after the device is switched to Computer Mode
+(hold VIEW -> Sources -> laptop+USB icon -> Yes).
+
+The script tries multiple candidate MessageBlock wire formats
+to discover the correct framing for SMEX control messages.
+"""
+import usb.core, usb.util, struct, time, os, sys
+
+VENDOR  = 0x15e4
+PRODUCT = 0xa008  # PRIME 4 Screen
+EP_OUT  = 0x02    # EP2 OUT bulk - host -> device
+EP_IN   = 0x81    # EP1 IN bulk  - device -> host
+EP_INT_OUT = 0x04 # EP4 OUT interrupt
+EP_INT_IN  = 0x83 # EP3 IN interrupt
+
+def open_device():
+    dev = usb.core.find(idVendor=VENDOR, idProduct=PRODUCT)
+    if dev is None:
+        print("PRIME 4 Screen not found. Is the device in Computer Mode?")
+        sys.exit(1)
+    if dev.is_kernel_driver_active(0):
+        dev.detach_kernel_driver(0)
+    usb.util.claim_interface(dev, 0)
+    print(f"Opened PRIME 4 Screen (bus {dev.bus}, dev {dev.address})")
+    return dev
+
+def read_all(dev, timeout=1000):
+    """Try to read from both IN endpoints."""
+    results = []
+    for ep, sz, name in [(EP_IN, 512, "bulk"), (EP_INT_IN, 64, "intr")]:
+        try:
+            d = dev.read(ep, sz, timeout=timeout)
+            results.append((name, bytes(d)))
+        except usb.core.USBTimeoutError:
+            pass
+        except Exception as e:
+            results.append((name, f"ERR:{e}"))
+    return results
+
+def probe(dev, label, payload, timeout=2000):
+    try:
+        n = dev.write(EP_OUT, payload, timeout=1000)
+        time.sleep(0.1)
+        resp = read_all(dev, timeout)
+        if resp:
+            for ch, d in resp:
+                if isinstance(d, bytes):
+                    print(f"  [{label}] RESPONSE on {ch}: {d.hex()}")
+                    return d
+        else:
+            print(f"  [{label}] no response ({n}B sent)")
+    except Exception as e:
+        print(f"  [{label}] error: {e}")
+    return None
+
+def smex_msg_utf8(type_str, payload_bytes=b""):
+    """
+    Candidate format 1: [4B BE total-len][4B BE type-str-len][type-str UTF-8][4B BE payload-len][payload]
+    """
+    type_b = type_str.encode('utf-8')
+    inner = struct.pack('>I', len(type_b)) + type_b + struct.pack('>I', len(payload_bytes)) + payload_bytes
+    return struct.pack('>I', len(inner)) + inner
+
+def smex_msg_cstr(type_str, payload_bytes=b""):
+    """
+    Candidate format 2: [4B BE total-len][null-terminated type-str][4B BE payload-len][payload]
+    """
+    type_b = type_str.encode('utf-8') + b'\x00'
+    inner = type_b + struct.pack('>I', len(payload_bytes)) + payload_bytes
+    return struct.pack('>I', len(inner)) + inner
+
+def smex_msg_id(type_id, payload_bytes=b""):
+    """
+    Candidate format 3: [4B BE total-len][4B BE type-id][payload]
+    (numeric type IDs, no string)
+    """
+    inner = struct.pack('>I', type_id) + payload_bytes
+    return struct.pack('>I', len(inner)) + inner
+
+def stagelinq_msg(msg_id, payload):
+    """
+    Candidate format 4: StageLinQ wire format [4B BE len][payload]
+    where payload = [4B BE msgID][content...]
+    """
+    inner = struct.pack('>I', msg_id) + payload
+    return struct.pack('>I', len(inner)) + inner
+
+def main():
+    dev = open_device()
+
+    print("\n--- Listening for spontaneous data (5s) ---")
+    for ch, d in read_all(dev, 5000):
+        if isinstance(d, bytes):
+            print(f"  Spontaneous {ch}: {d.hex()}")
+
+    token = os.urandom(16)
+
+    print("\n--- Format 1: [len][utf8-type-len][utf8-type][payload-len][payload] ---")
+    for t in ["smex.protocolversion", "smex.version"]:
+        probe(dev, f"fmt1:{t}", smex_msg_utf8(t, b"\x00\x00\x00\x01"))
+
+    print("\n--- Format 2: [len][cstr-type][payload-len][payload] ---")
+    for t in ["smex.protocolversion", "smex.version"]:
+        probe(dev, f"fmt2:{t}", smex_msg_cstr(t, b"\x00\x00\x00\x01"))
+
+    print("\n--- Format 3: [len][type-id uint32][payload] (numeric IDs 0..5) ---")
+    for i in range(6):
+        probe(dev, f"fmt3:id={i}", smex_msg_id(i, b"\x01"))
+
+    print("\n--- Format 4: StageLinQ service announcement ---")
+    def utf16(s): b = s.encode('utf-16-be'); return struct.pack('>I',len(b))+b
+    svc = token + utf16("Mixxx") + struct.pack('>H', 51337)
+    probe(dev, "stagelinq:service-announce", stagelinq_msg(0x00000000, svc))
+
+    print("\n--- Format 4b: StageLinQ services request ---")
+    probe(dev, "stagelinq:services-request", stagelinq_msg(0x00000002, token))
+
+    print("\n--- Format 5: plain [len][payload] with 'smex' magic ---")
+    for magic in [b"smex", b"SMEX", b"\x00\x00\x00\x01"]:
+        probe(dev, f"magic:{magic.hex()}", struct.pack('>I', 8) + magic + b"\x00"*4)
+
+    print("\n--- Format 6: interrupt OUT endpoint ---")
+    for t in ["smex.protocolversion", "smex.version"]:
+        try:
+            n = dev.write(EP_INT_OUT, smex_msg_utf8(t, b""), timeout=500)
+            time.sleep(0.1)
+            resp = read_all(dev, 1000)
+            if resp:
+                print(f"  [intr:{t}] RESPONSE: {resp}")
+            else:
+                print(f"  [intr:{t}] no response ({n}B sent)")
+        except Exception as e:
+            print(f"  [intr:{t}] error: {e}")
+
+    usb.util.release_interface(dev, 0)
+    print("\nDone.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
RE findings for the Prime 4 Computer Mode USB protocol, from firmware QML files, planck-remote-screen binary, and Engine DJ.exe.